### PR TITLE
Parse quote characters

### DIFF
--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -247,7 +247,6 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
     let mut tokens = Vec::new();
 
     // current index into `s`
-    //let mut index = 0;
     // start index of the current atom
     let mut cur_start = None;
 
@@ -322,7 +321,6 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
         } else if cur_start == None {
             cur_start = Some(index);
         }
-        //index += 1;
     }
     if let Some(start) = cur_start {
         tokens.push(make_sym(start, s.len() - 1, line, line_start));
@@ -406,6 +404,8 @@ mod tests {
         formats_as("(a \"b c\" d)", "(a \"b c\" d)");
         formats_as("(a \"(b c)\" d)", "(a \"(b c)\" d)");
         formats_as("(a b); \"(a b)\"", "(a b)");
+        formats_as("(a \"b \n c\" d)", "(a \"b \n c\" d)");
+        formats_as("(a \"b ; c\" d)", "(a \"b ; c\" d)");
     }
 
     #[test]

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -394,6 +394,9 @@ mod tests {
         formats_as("'(x)", "(quote (x))");
         formats_as("`(x)", "(quasiquote (x))");
         formats_as(",(x)", "(unquote (x))");
+        formats_as("('x)", "((quote x))");
+        formats_as("('(x))", "((quote (x)))");
+        formats_as("('x 'y)", "((quote x) (quote y))")
     }
 
     #[test]

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -248,7 +248,7 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
     let mut tokens = Vec::new();
 
     // current index into `s`
-    let mut index = 0;
+    //let mut index = 0;
     // start index of the current atom
     let mut cur_start = None;
 
@@ -271,7 +271,7 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
         Token::Sym { start, end, start_pos }
     };
 
-    for n in s.chars() {
+    for (index, n) in s.chars().enumerate() {
         if n == '"'{
             if is_in_string {
                 is_in_string=false;
@@ -324,10 +324,10 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
         } else if cur_start == None {
             cur_start = Some(index);
         }
-        index += 1;
+        //index += 1;
     }
     if let Some(start) = cur_start {
-        tokens.push(make_sym(start, index - 1, line, line_start));
+        tokens.push(make_sym(start, s.len() - 1, line, line_start));
     }
     tokens
 }

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -272,7 +272,7 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
     };
 
     for (index, n) in s.chars().enumerate() {
-        if n == '"'{
+        if n == '"' && !is_in_comment{
             if is_in_string {
                 is_in_string=false;
                 if let Some(start) = cur_start {

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -3,7 +3,6 @@ use aries_utils::disp_iter;
 use aries_utils::input::*;
 use std::convert::TryInto;
 use std::fmt::{Debug, Display, Formatter};
-use std::intrinsics::unreachable;
 
 pub type SAtom = aries_utils::input::Sym;
 

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -3,6 +3,7 @@ use aries_utils::disp_iter;
 use aries_utils::input::*;
 use std::convert::TryInto;
 use std::fmt::{Debug, Display, Formatter};
+use std::intrinsics::unreachable;
 
 pub type SAtom = aries_utils::input::Sym;
 
@@ -353,12 +354,12 @@ fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::s
         }
 
         Some(Token::RParen(_)) => bail!("Unexpected closing parenthesis"),
-        Some(quotting) => {
-            let (sym_quote, start) = match quotting {
+        Some(quoting) => {
+            let (sym_quote, start) = match quoting {
                 Token::Quote(s) => (Sym::new("quote"), s),
                 Token::QuasiQuote(s) => (Sym::new("quasiquote"), s),
                 Token::Unquote(s) => (Sym::new("unquote"), s),
-                _ => bail!("Unexpected token, should be Quote, QuasiQuote or Unquote"),
+                _ => unreachable!("Unexpected token, should be Quote, QuasiQuote or Unquote"),
             };
 
             let mut es = vec![SExpr::Atom(sym_quote)];

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -228,7 +228,6 @@ enum Token {
     Quote(Pos),
     QuasiQuote(Pos),
     Unquote(Pos),
-
 }
 
 pub fn parse<S: TryInto<Input>>(s: S) -> Result<SExpr>
@@ -272,21 +271,20 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
     };
 
     for (index, n) in s.chars().enumerate() {
-        if n == '"' && !is_in_comment{
+        if n == '"' && !is_in_comment {
             if is_in_string {
-                is_in_string=false;
+                is_in_string = false;
                 if let Some(start) = cur_start {
                     tokens.push(make_sym(start, index, line, line_start));
                     cur_start = None;
-                }else {
+                } else {
                     unreachable!("string should have a start")
                 }
             } else {
                 cur_start = Some(index);
                 is_in_string = true;
             }
-        }
-        else if n.is_whitespace() || n == '(' || n == ')' || n == ';' || is_in_comment
+        } else if n.is_whitespace() || n == '(' || n == ')' || n == ';' || is_in_comment
             //For quote, quasiquote and unquote support
             || n == '\'' || n == '`' || n == ','
         {
@@ -334,7 +332,7 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
 
 fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::sync::Arc<Input>) -> Result<SExpr> {
     match tokens.next() {
-        Some(Token::Sym { start, end, start_pos })=> {
+        Some(Token::Sym { start, end, start_pos }) => {
             let s = &src.text.as_str()[*start..=*end];
             let s = s.to_ascii_lowercase();
             let span = Span {
@@ -386,7 +384,7 @@ fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::s
             Ok(SExpr::List(SList {
                 list: es,
                 source: src.clone(),
-                span: Span::new(*start, *end),
+                span: Span::new(*start, end),
             }))
         }
         None => bail!("Unexpected end of output"),
@@ -407,7 +405,7 @@ mod tests {
     fn parsing_string() {
         formats_as("(a \"b c\" d)", "(a \"b c\" d)");
         formats_as("(a \"(b c)\" d)", "(a \"(b c)\" d)");
-        formats_as("(a b); \"(a b)\"","(a b)");
+        formats_as("(a b); \"(a b)\"", "(a b)");
     }
 
     #[test]

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -380,13 +380,13 @@ fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::s
 
             let mut es = vec![SExpr::Atom(sym_quote)];
             let e = read(tokens, src)?;
-            //let loc = e.loc();
+            let end = e.loc().span().end;
             es.push(e);
             //Compute the span
             Ok(SExpr::List(SList {
                 list: es,
                 source: src.clone(),
-                span: Span::new(*start, *start), //TODO: find a way to declare the span
+                span: Span::new(*start, *end),
             }))
         }
         None => bail!("Unexpected end of output"),
@@ -407,6 +407,7 @@ mod tests {
     fn parsing_string() {
         formats_as("(a \"b c\" d)", "(a \"b c\" d)");
         formats_as("(a \"(b c)\" d)", "(a \"(b c)\" d)");
+        formats_as("(a b); \"(a b)\"","(a b)");
     }
 
     #[test]

--- a/planning/src/parsing/sexpr.rs
+++ b/planning/src/parsing/sexpr.rs
@@ -271,7 +271,8 @@ fn tokenize(source: std::sync::Arc<Input>) -> Vec<Token> {
     for n in s.chars() {
         if n.is_whitespace() || n == '(' || n == ')' || n == ';' || is_in_comment
             //For quote, quasiquote and unquote support
-            || n == '\'' || n == '`' || n == ',' {
+            || n == '\'' || n == '`' || n == ','
+        {
             // if we were parsing a symbol, we have reached its end
             if let Some(start) = cur_start {
                 tokens.push(make_sym(start, index - 1, line, line_start));
@@ -357,11 +358,10 @@ fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::s
                 Token::Quote(s) => (Sym::new("quote"), s),
                 Token::QuasiQuote(s) => (Sym::new("quasiquote"), s),
                 Token::Unquote(s) => (Sym::new("unquote"), s),
-                _ => bail!("Unexpected token, should be Quote, QuasiQuote or Unquote")
+                _ => bail!("Unexpected token, should be Quote, QuasiQuote or Unquote"),
             };
 
-            let mut es = Vec::new();
-            es.push(SExpr::Atom(sym_quote));
+            let mut es = vec![SExpr::Atom(sym_quote)];
             let e = read(tokens, src)?;
             //let loc = e.loc();
             es.push(e);
@@ -369,7 +369,7 @@ fn read(tokens: &mut std::iter::Peekable<core::slice::Iter<Token>>, src: &std::s
             Ok(SExpr::List(SList {
                 list: es,
                 source: src.clone(),
-                span: Span::new(*start,*start) //TODO: find a way to declare the span
+                span: Span::new(*start, *start), //TODO: find a way to declare the span
             }))
         }
         None => bail!("Unexpected end of output"),

--- a/utils/src/input.rs
+++ b/utils/src/input.rs
@@ -168,6 +168,10 @@ impl Loc {
         }
     }
 
+    pub fn span(self) -> Span {
+        self.span
+    }
+
     pub fn underlined(&self) -> impl Display + '_ {
         self.source.underlined(self.span)
     }


### PR DESCRIPTION
- Modification of the parse function to support quote, quasiquote and unquote characters.
- Modification of enum Token:
```rust
enum Token {
    Sym { start: usize, end: usize, start_pos: Pos },
    LParen(Pos),
    RParen(Pos),
    //new fields
    Quote(Pos),
    QuasiQuote(Pos),
    Unquote(Pos),
}
```
- Modification of the function tokenize to support new kind of Token.
- Modification of read to transform new tokens into corresponding symbols and construct and SList containing the quote expression.