### PR TITLE
Compile UP protobuf definitions as feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,13 @@ jobs:
   unified_planning_api:
     name: Check unified planning API
     runs-on: ubuntu-20.04
+    env: # Make sure we have fast binaries and debuggable binaries
+      CARGO_PROFILE_RELEASE_DEBUG: false
+      CARGO_PROFILE_DEV_DEBUG: false
+      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
+      CARGO_PROFILE_DEV_OPT_LEVEL: 3
+      CARGO_PROFILE_DEV_LTO: thin
+      RUST_BACKTRACE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -106,35 +113,9 @@ jobs:
           git diff --exit-code
       - name: Check if bindings are up to date
         run: |
-          # Check if the API is up to date
           printf "Checking if the API is up to date...\n"
-          # git submodule update --init
-          # rm grpc/api/src/unified_planning.proto
-          # cp ext/up/unified_planning/unified_planning/grpc/unified_planning.proto grpc/api/src/
+          sudo apt install -y libprotobuf-dev protobuf-compiler
           cargo build --features=generate_bindings
           git diff --exit-code
-
-  grpc:
-    name: GRPC Solving
-    runs-on: ubuntu-20.04
-    env: # Make sure we have fast binaries and debuggable binaries
-      CARGO_PROFILE_RELEASE_DEBUG: false
-      CARGO_PROFILE_DEV_DEBUG: false
-      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
-      CARGO_PROFILE_DEV_OPT_LEVEL: 3
-      CARGO_PROFILE_DEV_LTO: thin
-      RUST_BACKTRACE: false
-    steps:
-      - name: Install protobuf
-        run: sudo apt install libprotobuf-dev protobuf-compiler
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      # - uses: Swatinem/rust-cache@v1
-      #   with:
-      #     cache-on-failure: true
-      - name: LCP Solving (Unified Planning)
+      - name: GRPC Server Solving
         run: python ./ci/grpc.py

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
         run: ./ci/lcp.sh
 
   unified_planning_api:
-    name: Check unified planning API
+    name: Unified Planning API
     runs-on: ubuntu-20.04
     env: # Make sure we have fast binaries and debuggable binaries
       CARGO_PROFILE_RELEASE_DEBUG: false
@@ -111,10 +111,11 @@ jobs:
           rm grpc/api/src/unified_planning.proto
           cp ext/up/unified_planning/unified_planning/grpc/unified_planning.proto grpc/api/src/
           git diff --exit-code
+      - name: Install Protobuf
+        run: sudo apt install -y libprotobuf-dev protobuf-compiler
       - name: Check if bindings are up to date
         run: |
           printf "Checking if the API is up to date...\n"
-          sudo apt install -y libprotobuf-dev protobuf-compiler
           cargo build --features=generate_bindings
           git diff --exit-code
       - name: GRPC Server Solving

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,8 +86,8 @@ jobs:
       - name: LCP Solving (PDDL & HDDL)
         run: ./ci/lcp.sh
 
-  up_proto_definition:
-    name: Check for new protobuf definitions
+  unified_planning_api:
+    name: Check unified planning API
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -100,9 +100,18 @@ jobs:
         run: |
           # Download the latest protobuf definitions
           printf "Checking for new protobuf definitions...\n"
-          git submodule update --init 
+          git submodule update --init
           rm grpc/api/src/unified_planning.proto
           cp ext/up/unified_planning/unified_planning/grpc/unified_planning.proto grpc/api/src/
+          git diff --exit-code
+      - name: Check if bindings are up to date
+        run: |
+          # Check if the API is up to date
+          printf "Checking if the API is up to date...\n"
+          # git submodule update --init
+          # rm grpc/api/src/unified_planning.proto
+          # cp ext/up/unified_planning/unified_planning/grpc/unified_planning.proto grpc/api/src/
+          cargo build --features=generate_bindings
           git diff --exit-code
 
   grpc:

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -2,6 +2,18 @@
 
 This module holds the functionality for the gRPC library integrated into Aries. The implementation is currently focused towards [**unified_planning**](https://github.com/aiplan4eu/unified-planning).
 
+<!-- TODO: Update README for UP Server and Usage Information -->
+
+## GRPC API
+
+To build the grpc API for the `up-server`, run the following command:
+
+```bash
+cargo build --features=unified_planning
+```
+
+If you are experiencing any issues with building/updating the rust definitions, perform `cargo clean` and try again.
+
 ## Information
 
 Currently the server can be run in two modes:

--- a/grpc/README.md
+++ b/grpc/README.md
@@ -2,53 +2,49 @@
 
 This module holds the functionality for the gRPC library integrated into Aries. The implementation is currently focused towards [**unified_planning**](https://github.com/aiplan4eu/unified-planning).
 
-<!-- TODO: Update README for UP Server and Usage Information -->
-
 ## GRPC API
 
-To build the grpc API for the `up-server`, run the following command:
+To generate rust bindings for the unified planning [protobuf definition](./api/src/unified_planning.proto), run the following command:
 
 ```bash
-cargo build --features=unified_planning
+cargo build --features=generate_bindings
 ```
+
+The generated code will be located in [`api/src/unified_planning.rs`](./api/src/unified_planning.rs).
 
 If you are experiencing any issues with building/updating the rust definitions, perform `cargo clean` and try again.
 
-## Information
+## UP Server
+
+The UP server is a gRPC server that can be used with unified planning.
 
 Currently the server can be run in two modes:
 
-- The server can take in a single file and process it. Once the problem is solved, send the plan back to **unified_planning**. This is useful for testing.
-- The server can wait for up-server to send a problem description, process it, solve it and send back the solution.
+- The server can take in a single encoded file and process it. Once the problem is solved, send the plan back to **unified_planning**. This is useful for testing.
+- The server can wait for a problem description request, process it, solve it and send back the solution respecting the protobuf definition.
 
-## Setup
+### Usage
 
-To setup the server for testing, you will use the following:
+To build the server, run the following command:
 
-- The problem description file in `.bin` format. Some problems are available in [this location](../ext/up/bins/). The information related to generating all problems is available at this [location](../ext/up/README.md).
-
-## Usage
+```bash
+cargo build --features=generate_bindings --bin up-server
+```
 
 To run the gRPC server, use the following command:
 
 ```bash
-cargo run --release --bin up-server <path-to-binary>
-```
-
-or simply,
-
-```bash
+# To launch the server directly at 0.0.0.0:2222
 cargo run --bin up-server
+
+# To launch the server with a custom port
+cargo run --bin up-server -- --address 0.0.0.0:50051
+
+# To launch the server with a problem file
+cargo run --release --bin up-server -- --file-path <root-of-repo>/ext/up/bins/problems/matchcellar.bin
+
+# To launch the server with a problem file and a custom port
+cargo run --release --bin up-server -- --address 0.0.0.0:50051 --file-path <root-of-repo>/ext/up/bins/problems/matchcellar.bin
 ```
 
-For example:
-
-```bash
-cargo run --release --bin up-server ../ext/up/bins/problems/matchcellar.bin
-```
-
-## Todo
-
-- [ ] Add support for temporal constraints
-- [ ] Validate the server for plans / Unsupported problems
-- [ ]Export the server to different architectures
+More example problems are available in [this directory](../ext/up/bins/).

--- a/grpc/api/Cargo.toml
+++ b/grpc/api/Cargo.toml
@@ -15,4 +15,4 @@ tonic = "0.8"
 tonic-build = {version = "0.8", optional = true}
 
 [features]
-unified_planning = ["tonic-build"]
+generate_bindings = ["tonic-build"]

--- a/grpc/api/Cargo.toml
+++ b/grpc/api/Cargo.toml
@@ -7,10 +7,12 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 async-trait = "0.1"
-prost = { default-features = false, version = "0.11" }
-regex = { default-features = false, version = "1" }
+prost = {default-features = false, version = "0.11"}
+regex = {default-features = false, version = "1"}
 tonic = "0.8"
-
 
 [build-dependencies]
 tonic-build = "0.8"
+
+[features]
+unified_planning = []

--- a/grpc/api/Cargo.toml
+++ b/grpc/api/Cargo.toml
@@ -12,7 +12,7 @@ regex = {default-features = false, version = "1"}
 tonic = "0.8"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = {version = "0.8", optional = true}
 
 [features]
-unified_planning = []
+unified_planning = ["tonic-build"]

--- a/grpc/api/build.rs
+++ b/grpc/api/build.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 //Build GRPC server and client for UPF planning service
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn build_definitions() -> Result<(), Box<dyn std::error::Error>> {
     let proto_file = "src/unified_planning.proto";
 
     let x: [&str; 0] = [];
@@ -15,4 +15,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     fs::rename("src/_.rs", "src/unified_planning.rs")?;
 
     Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if cfg!(feature = "unified_planning") {
+        build_definitions()
+    } else {
+        println!("To compile the unified planning definitions, run cargo build --features=unified_planning");
+        Ok(())
+    }
 }

--- a/grpc/api/build.rs
+++ b/grpc/api/build.rs
@@ -1,5 +1,5 @@
 //Build GRPC server and client for UPF planning service
-#[cfg(feature = "unified_planning")]
+#[cfg(feature = "generate_bindings")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::fs;
     let proto_file = "src/unified_planning.proto";
@@ -17,7 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[cfg(not(feature = "unified_planning"))]
+#[cfg(not(feature = "generate_bindings"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }

--- a/grpc/api/build.rs
+++ b/grpc/api/build.rs
@@ -1,7 +1,7 @@
-use std::fs;
-
 //Build GRPC server and client for UPF planning service
-fn build_definitions() -> Result<(), Box<dyn std::error::Error>> {
+#[cfg(feature = "unified_planning")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
     let proto_file = "src/unified_planning.proto";
 
     let x: [&str; 0] = [];
@@ -17,11 +17,7 @@ fn build_definitions() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(not(feature = "unified_planning"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    if cfg!(feature = "unified_planning") {
-        build_definitions()
-    } else {
-        println!("To compile the unified planning definitions, run cargo build --features=unified_planning");
-        Ok(())
-    }
+    Ok(())
 }

--- a/grpc/api/src/unified_planning.rs
+++ b/grpc/api/src/unified_planning.rs
@@ -1,56 +1,39 @@
-// =============== Types ================
-
-// Type of expressions are represented as strings in protobuf format.
-// A type might be, e.g., "int", "bool" or "location", where the latter is a problem-specific type.
-
-// Built-in types are namespaced with the `up:` prefix:
-//   - "up:bool"
-//   - "up:integer"
-//   - "up:real"
-//   - "up:time"
-//
-// Any other string (e.g. "location") refers to a symbolic type and must have been declared in the problem definition.
-
-// We can also consider restrictions to int/reals with specific syntax (e.g. "up:integer\[0,100\]").
-
-// ================== Expressions ====================
-
 /// As in s-expression, an Expression is either an atom or list representing the application of some parameters to a function/fluent.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Expression {
     /// If non-empty, the expression is a single atom.
     /// For instance `3`, `+`, `kitchen`, `at-robot`, ...
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub atom: ::core::option::Option<Atom>,
     /// If the `atom` field is empty, then the expression is a list of sub-expressions,
     /// typically representing the application of some arguments to a function or fluent.
     /// For instance `(+ 1 3)`, (at-robot l1)`, `(>= (battery_level) 20)`
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub list: ::prost::alloc::vec::Vec<Expression>,
     /// Type of the expression. For instance "int", "location", ...
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub r#type: ::prost::alloc::string::String,
     /// Kind of the expression, specifying the content of the expression.
     /// This is intended to facilitate parsing of the expression.
-    #[prost(enumeration="ExpressionKind", tag="4")]
+    #[prost(enumeration = "ExpressionKind", tag = "4")]
     pub kind: i32,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Atom {
-    #[prost(oneof="atom::Content", tags="1, 2, 3, 4")]
+    #[prost(oneof = "atom::Content", tags = "1, 2, 3, 4")]
     pub content: ::core::option::Option<atom::Content>,
 }
 /// Nested message and enum types in `Atom`.
 pub mod atom {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Symbol(::prost::alloc::string::String),
-        #[prost(int64, tag="2")]
+        #[prost(int64, tag = "2")]
         Int(i64),
-        #[prost(message, tag="3")]
+        #[prost(message, tag = "3")]
         Real(super::Real),
-        #[prost(bool, tag="4")]
+        #[prost(bool, tag = "4")]
         Boolean(bool),
     }
 }
@@ -59,87 +42,93 @@ pub mod atom {
 /// Notably, if this number is an integer, then it is guaranteed that `denominator == 1`.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Real {
-    #[prost(int64, tag="1")]
+    #[prost(int64, tag = "1")]
     pub numerator: i64,
-    #[prost(int64, tag="2")]
+    #[prost(int64, tag = "2")]
     pub denominator: i64,
 }
-// ============= Domains ====================
-
 /// Declares the existence of a symbolic type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TypeDeclaration {
     /// Name of the type that is declared.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub type_name: ::prost::alloc::string::String,
     /// Optional. If the string is non-empty, this is the parent type of `type_name`.
     /// If set, the parent type must have been previously declared (i.e. should appear earlier in the problem's type declarations.
     /// feature: HIERARCHICAL_TYPING
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub parent_type: ::prost::alloc::string::String,
 }
 /// Parameter of a fluent or of an action
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Parameter {
     /// Name of the parameter.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Type of the parameter.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub r#type: ::prost::alloc::string::String,
 }
 /// A state-dependent variable.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Fluent {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Return type of the fluent.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub value_type: ::prost::alloc::string::String,
     /// Typed and named parameters of the fluent.
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub parameters: ::prost::alloc::vec::Vec<Parameter>,
     /// If non-empty, then any state variable using this fluent that is not explicitly given a value in the initial state
     /// will be assumed to have this default value.
     /// This allows mimicking the closed world assumption by setting a "false" default value to predicates.
     /// Note that in the initial state of the problem message, it is assumed that all default values are set.
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub default_value: ::core::option::Option<Expression>,
 }
 /// Declares an object with the given name and type.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectDeclaration {
     /// Name of the object.
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Type of the object.
     /// The type must have been previously declared in the problem definition.
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub r#type: ::prost::alloc::string::String,
 }
-// ========= Actions ========
-
 /// An effect expression is of the form `FLUENT OP VALUE`.
 /// We explicitly restrict the different types of effects by setting the allowed operators.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EffectExpression {
-    #[prost(enumeration="effect_expression::EffectKind", tag="1")]
+    #[prost(enumeration = "effect_expression::EffectKind", tag = "1")]
     pub kind: i32,
     /// Expression that must be of the STATE_VARIABLE kind.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub fluent: ::core::option::Option<Expression>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub value: ::core::option::Option<Expression>,
     /// Optional. If the effect is conditional, then the following field must be set.
     /// In this case, the `effect` will only be applied if the `condition`` holds.
     /// If the effect is unconditional, the effect is set to the constant 'true' value.
     /// features: CONDITIONAL_EFFECT
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub condition: ::core::option::Option<Expression>,
 }
 /// Nested message and enum types in `EffectExpression`.
 pub mod effect_expression {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum EffectKind {
         /// The `fluent` is set to the corresponding `value`
@@ -169,41 +158,41 @@ pub mod effect_expression {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Effect {
     /// Required. The actual effect that should take place.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub effect: ::core::option::Option<EffectExpression>,
     /// Optional. If the effect is within a durative action, the following must be set and will specify when the effect takes place.
     /// features: DURATIVE_ACTIONS
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub occurrence_time: ::core::option::Option<Timing>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Condition {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub cond: ::core::option::Option<Expression>,
     /// Optional. Must be set for durative actions where it specifies the temporal interval
     /// over which when the condition should hold.
     /// features: DURATIVE_ACTIONS
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub span: ::core::option::Option<TimeInterval>,
 }
 /// Unified action representation that represents any kind of actions.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Action {
     /// Action name. E.g. "move"
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Typed and named parameters of the action.
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub parameters: ::prost::alloc::vec::Vec<Parameter>,
     /// If set, the action is durative. Otherwise it is instantaneous.
     /// features: DURATIVE_ACTIONS
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub duration: ::core::option::Option<Duration>,
     /// Conjunction of conditions that must hold for the action to be applicable.
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub conditions: ::prost::alloc::vec::Vec<Condition>,
     /// Conjunction of effects as a result of applying this action.
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub effects: ::prost::alloc::vec::Vec<Effect>,
 }
 /// Symbolic reference to an absolute time.
@@ -218,17 +207,27 @@ pub struct Action {
 /// by adding an additional field with the identifier of an action/subtask.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timepoint {
-    #[prost(enumeration="timepoint::TimepointKind", tag="1")]
+    #[prost(enumeration = "timepoint::TimepointKind", tag = "1")]
     pub kind: i32,
     /// If non-empty, identifies the container of which we are extracting the start/end timepoint.
     /// In the context of a task-network or of a method, this could be the `id` of one of the subtasks.
     /// feature: hierarchies
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub container_id: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `Timepoint`.
 pub mod timepoint {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum TimepointKind {
         /// Global start of the planning problem. This is context independent and represents the time at which the initial state holds.
@@ -259,9 +258,9 @@ pub mod timepoint {
 /// Note that an absolute time can be defined by setting the `delay` relative to the `GLOBAL_START`` which is the reference time.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timing {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub timepoint: ::core::option::Option<Timepoint>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub delay: ::core::option::Option<Real>,
 }
 /// An interval `[lower, upper]` where `lower` and `upper` are arbitrary expressions.
@@ -269,13 +268,13 @@ pub struct Timing {
 /// opened on left and right side respectively.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Interval {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub is_left_open: bool,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub lower: ::core::option::Option<Expression>,
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub is_right_open: bool,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub upper: ::core::option::Option<Expression>,
 }
 /// A contiguous slice of time represented as an interval `[lower, upper]` where `lower` and `upper` are time references.
@@ -283,35 +282,33 @@ pub struct Interval {
 /// opened on left and right side respectively.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimeInterval {
-    #[prost(bool, tag="1")]
+    #[prost(bool, tag = "1")]
     pub is_left_open: bool,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub lower: ::core::option::Option<Timing>,
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub is_right_open: bool,
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub upper: ::core::option::Option<Timing>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
     /// / The duration of the action can be freely chosen within the indicated bounds
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub controllable_in_bounds: ::core::option::Option<Interval>,
 }
-// ============== Hierarchies ====================
-
 /// Declares an abstract task together with its expected parameters.
 ///
 /// Example: goto(robot: Robot, destination: Location)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AbstractTaskDeclaration {
     /// Example: "goto"
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Example:
     ///   - robot: Robot
     ///   - destination: Location
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub parameters: ::prost::alloc::vec::Vec<Parameter>,
 }
 /// Representation of an abstract or primitive task that should be achieved,
@@ -325,7 +322,7 @@ pub struct Task {
     /// The `id` is notably used to refer to the start/end of the task.
     ///
     /// Example: t1
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// Name of the task that should be achieved. It might either
     ///   - an abstract task if the name is the one of a task declared in the problem
@@ -334,12 +331,12 @@ pub struct Task {
     /// Example:
     ///   - "goto" (abstract task)
     ///   - "move" (action / primitive task)
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub task_name: ::prost::alloc::string::String,
     /// Example: (for a "goto" task)
     ///   - robot    (a parameter from an outer scope)
     ///   - KITCHEN  (a constant symbol in the problem)
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub parameters: ::prost::alloc::vec::Vec<Expression>,
 }
 /// A method describes one possible way of achieving a task.
@@ -351,17 +348,17 @@ pub struct Method {
     /// This is mostly used for user facing output or plan validation.
     ///
     /// Example: "m-recursive-goto"
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Example: [robot: Robot, source: Location, intermediate: Location, destination: Location]
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub parameters: ::prost::alloc::vec::Vec<Parameter>,
     /// The task that is achieved by the method.
     /// A subset of the parameters of the method will typically be used to
     /// define the task that is achieved.
     ///
     /// Example: goto(robot, destination)
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub achieved_task: ::core::option::Option<Task>,
     /// A set of subtasks that should be achieved to carry out the method.
     /// Note that the order of subtasks is irrelevant and that any ordering constraint should be
@@ -370,7 +367,7 @@ pub struct Method {
     /// Example:
     ///   - t1: (move robot source intermediate)
     ///   - t2: goto(robot destination)
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub subtasks: ::prost::alloc::vec::Vec<Task>,
     /// Constraints enable the definition of ordering constraints as well as constraints
     /// on the allowed instantiation of the method's parameters.
@@ -378,7 +375,7 @@ pub struct Method {
     /// Example:
     ///   - end(t1) < start(t2)
     ///   - source != intermediate
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub constraints: ::prost::alloc::vec::Vec<Expression>,
     /// Conjunction of conditions that must hold for the method to be applicable.
     /// As for the conditions of actions, these can be temporally qualified to refer to intermediate timepoints.
@@ -389,7 +386,7 @@ pub struct Method {
     ///   - \[start\] loc(robot) == source
     ///   - \[end(t1)\] loc(robot) == intermediate
     ///   - \[end\] loc(robot) == destination
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub conditions: ::prost::alloc::vec::Vec<Condition>,
 }
 /// A task network defines a set of subtasks and associated constraints.
@@ -399,49 +396,47 @@ pub struct Method {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TaskNetwork {
     /// robot: Location
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub variables: ::prost::alloc::vec::Vec<Parameter>,
     /// t1: goto(robot, KITCHEN)
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub subtasks: ::prost::alloc::vec::Vec<Task>,
     /// end(t1) <= 100
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub constraints: ::prost::alloc::vec::Vec<Expression>,
 }
 /// Represents the hierarchical part of a problem.
 /// features: hierarchical
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Hierarchy {
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub abstract_tasks: ::prost::alloc::vec::Vec<AbstractTaskDeclaration>,
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub methods: ::prost::alloc::vec::Vec<Method>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub initial_task_network: ::core::option::Option<TaskNetwork>,
 }
-// ============== Problem =========================
-
 /// A Goal is currently an expression that must hold either:
 /// - in the final state,
 /// - over a specific temporal interval (under the `timed_goals` features)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Goal {
     /// Goal expression that must hold in the final state.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub goal: ::core::option::Option<Expression>,
     /// Optional. If specified the goal should hold over the specified temporal interval (instead of on the final state).
     /// features: TIMED_GOALS
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub timing: ::core::option::Option<TimeInterval>,
 }
 /// Represents an effect that will occur sometime beyond the initial state. (similar to timed initial literals)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TimedEffect {
     /// Required. An effect expression that will take place sometime in the future (i.e. not at the intial state) as specified by the temporal qualifiation.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub effect: ::core::option::Option<EffectExpression>,
     /// Required. Temporal qualification denoting when the timed fact will occur.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub occurrence_time: ::core::option::Option<Timing>,
 }
 /// An assignment of a value to a fluent, as it appears in the initial state definition.
@@ -449,29 +444,29 @@ pub struct TimedEffect {
 pub struct Assignment {
     /// State variable that is assigned the `value`.
     /// It should be an expression of the STATE_VARIABLE kind for which all parameters are of the CONSTANT kind.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub fluent: ::core::option::Option<Expression>,
     /// An expression of the CONSTANT kind, denoting the value take by the state variable.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub value: ::core::option::Option<Expression>,
 }
 /// Represents a goal associated with a cost, used to define oversubscription planning.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GoalWithCost {
     /// Goal expression
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub goal: ::core::option::Option<Expression>,
     /// The cost
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub cost: ::core::option::Option<Real>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Metric {
-    #[prost(enumeration="metric::MetricKind", tag="1")]
+    #[prost(enumeration = "metric::MetricKind", tag = "1")]
     pub kind: i32,
     /// Expression to minimize/maximize in the final state.
     /// Empty, if the `kind` is not {MIN/MAX}IMIZE_EXPRESSION_ON_FINAL_STATE
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub expression: ::core::option::Option<Expression>,
     /// If `kind == MINIMIZE_ACTION_COSTS``, then each action is associated to a cost expression.
     ///
@@ -479,18 +474,31 @@ pub struct Metric {
     /// In particular, for this metric to be useful in many practical problems, the cost expression
     /// should allow referring to the action parameters (and possibly the current state at the action start/end).
     /// This is very awkward to do in this setting where the expression is detached from its scope.
-    #[prost(map="string, message", tag="3")]
-    pub action_costs: ::std::collections::HashMap<::prost::alloc::string::String, Expression>,
-    #[prost(message, optional, tag="4")]
+    #[prost(map = "string, message", tag = "3")]
+    pub action_costs: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        Expression,
+    >,
+    #[prost(message, optional, tag = "4")]
     pub default_action_cost: ::core::option::Option<Expression>,
     /// List of goals used to define the oversubscription planning problem.
     /// Empty, if the `kind` is not OVERSUBSCRIPTION
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub goals: ::prost::alloc::vec::Vec<GoalWithCost>,
 }
 /// Nested message and enum types in `Metric`.
 pub mod metric {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum MetricKind {
         /// Minimize the action costs expressed in the `action_costs` field
@@ -515,10 +523,16 @@ pub mod metric {
         pub fn as_str_name(&self) -> &'static str {
             match self {
                 MetricKind::MinimizeActionCosts => "MINIMIZE_ACTION_COSTS",
-                MetricKind::MinimizeSequentialPlanLength => "MINIMIZE_SEQUENTIAL_PLAN_LENGTH",
+                MetricKind::MinimizeSequentialPlanLength => {
+                    "MINIMIZE_SEQUENTIAL_PLAN_LENGTH"
+                }
                 MetricKind::MinimizeMakespan => "MINIMIZE_MAKESPAN",
-                MetricKind::MinimizeExpressionOnFinalState => "MINIMIZE_EXPRESSION_ON_FINAL_STATE",
-                MetricKind::MaximizeExpressionOnFinalState => "MAXIMIZE_EXPRESSION_ON_FINAL_STATE",
+                MetricKind::MinimizeExpressionOnFinalState => {
+                    "MINIMIZE_EXPRESSION_ON_FINAL_STATE"
+                }
+                MetricKind::MaximizeExpressionOnFinalState => {
+                    "MAXIMIZE_EXPRESSION_ON_FINAL_STATE"
+                }
                 MetricKind::Oversubscription => "OVERSUBSCRIPTION",
             }
         }
@@ -527,61 +541,59 @@ pub mod metric {
 /// features: ACTION_BASED
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Problem {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub domain_name: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub problem_name: ::prost::alloc::string::String,
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub types: ::prost::alloc::vec::Vec<TypeDeclaration>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub fluents: ::prost::alloc::vec::Vec<Fluent>,
-    #[prost(message, repeated, tag="5")]
+    #[prost(message, repeated, tag = "5")]
     pub objects: ::prost::alloc::vec::Vec<ObjectDeclaration>,
     /// List of actions in the domain.
-    #[prost(message, repeated, tag="6")]
+    #[prost(message, repeated, tag = "6")]
     pub actions: ::prost::alloc::vec::Vec<Action>,
     /// Initial state, including default values of state variables.
-    #[prost(message, repeated, tag="7")]
+    #[prost(message, repeated, tag = "7")]
     pub initial_state: ::prost::alloc::vec::Vec<Assignment>,
     /// Facts and effects that are expected to occur strictly later than the initial state.
     /// features: TIMED_EFFECT
-    #[prost(message, repeated, tag="8")]
+    #[prost(message, repeated, tag = "8")]
     pub timed_effects: ::prost::alloc::vec::Vec<TimedEffect>,
     /// Goals of the planning problem.
-    #[prost(message, repeated, tag="9")]
+    #[prost(message, repeated, tag = "9")]
     pub goals: ::prost::alloc::vec::Vec<Goal>,
     /// all features of the problem
-    #[prost(enumeration="Feature", repeated, tag="10")]
+    #[prost(enumeration = "Feature", repeated, tag = "10")]
     pub features: ::prost::alloc::vec::Vec<i32>,
     /// The plan quality metrics
-    #[prost(message, repeated, tag="11")]
+    #[prost(message, repeated, tag = "11")]
     pub metrics: ::prost::alloc::vec::Vec<Metric>,
     /// If the problem is hierarchical, defines the tasks and methods as well as the initial task network.
     /// features: hierarchical
-    #[prost(message, optional, tag="12")]
+    #[prost(message, optional, tag = "12")]
     pub hierarchy: ::core::option::Option<Hierarchy>,
 }
-// =================== Plan ================
-
 /// Representation of an action instance that appears in a plan.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ActionInstance {
     /// Optional. A unique identifier of the action that might be used to refer to it (e.g. in HTN plans).
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
     /// name of the action
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub action_name: ::prost::alloc::string::String,
     /// Parameters of the action instance, required to be constants.
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub parameters: ::prost::alloc::vec::Vec<Atom>,
     /// Start time of the action. The default 0 value is OK in the case of non-temporal planning
     /// feature: \[DURATIVE_ACTIONS\]
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub start_time: ::core::option::Option<Real>,
     /// End time of the action. The default 0 value is OK in the case of non-temporal planning
     /// feature: \[DURATIVE_ACTIONS\]
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub end_time: ::core::option::Option<Real>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -589,28 +601,39 @@ pub struct Plan {
     /// An ordered sequence of actions that appear in the plan.
     /// The order of the actions in the list must be compatible with the partial order of the start times.
     /// In case of non-temporal planning, this allows having all start time at 0 and only rely on the order in this sequence.
-    #[prost(message, repeated, tag="1")]
+    #[prost(message, repeated, tag = "1")]
     pub actions: ::prost::alloc::vec::Vec<ActionInstance>,
 }
-// =============== RPC API =======================
-
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlanRequest {
     /// Problem that should be solved.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub problem: ::core::option::Option<Problem>,
-    #[prost(enumeration="plan_request::Mode", tag="2")]
+    #[prost(enumeration = "plan_request::Mode", tag = "2")]
     pub resolution_mode: i32,
     /// Max allowed runtime time in seconds.
-    #[prost(double, tag="3")]
+    #[prost(double, tag = "3")]
     pub timeout: f64,
     /// Engine specific options to be passed to the engine
-    #[prost(map="string, string", tag="4")]
-    pub engine_options: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(map = "string, string", tag = "4")]
+    pub engine_options: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 /// Nested message and enum types in `PlanRequest`.
 pub mod plan_request {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Mode {
         Satisfiable = 0,
@@ -632,10 +655,10 @@ pub mod plan_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidationRequest {
     /// Problem to be validated.
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub problem: ::core::option::Option<Problem>,
     /// Plan to validate.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub plan: ::core::option::Option<Plan>,
 }
 /// A freely formatted logging message.
@@ -643,14 +666,24 @@ pub struct ValidationRequest {
 /// Criticality level is expected to be used by an end user to decide the level of verbosity.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LogMessage {
-    #[prost(enumeration="log_message::LogLevel", tag="1")]
+    #[prost(enumeration = "log_message::LogLevel", tag = "1")]
     pub level: i32,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub message: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `LogMessage`.
 pub mod log_message {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum LogLevel {
         Debug = 0,
@@ -677,29 +710,42 @@ pub mod log_message {
 /// Contains the engine exit status as well as the best plan found if any.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PlanGenerationResult {
-    #[prost(enumeration="plan_generation_result::Status", tag="1")]
+    #[prost(enumeration = "plan_generation_result::Status", tag = "1")]
     pub status: i32,
     /// Optional. Best plan found if any.
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub plan: ::core::option::Option<Plan>,
     /// A set of engine specific values that can be reported, for instance
     /// - "grounding-time": "10ms"
     /// - "expanded-states": "1290"
-    #[prost(map="string, string", tag="3")]
-    pub metrics: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(map = "string, string", tag = "3")]
+    pub metrics: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Optional log messages about the engine's activity.
     /// Note that it should not be expected that logging messages are visible to the end user.
     /// If used in conjunction with INTERNAL_ERROR or UNSUPPORTED_PROBLEM, it would be expected to have at least one log message at the ERROR level.
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub log_messages: ::prost::alloc::vec::Vec<LogMessage>,
     /// Synthetic description of the engine that generated this message.
-    #[prost(message, optional, tag="5")]
+    #[prost(message, optional, tag = "5")]
     pub engine: ::core::option::Option<Engine>,
 }
 /// Nested message and enum types in `PlanGenerationResult`.
 pub mod plan_generation_result {
     /// ==== Engine stopped normally ======
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum Status {
         /// Valid plan found
@@ -713,10 +759,6 @@ pub mod plan_generation_result {
         /// The engine was not able to find a solution but does not give any guarantee that none exist
         /// (i.e. the engine might not be complete)
         UnsolvableIncompletely = 3,
-        // ====== Engine exited before making any conclusion ====
-        // Search stopped before concluding SOLVED_OPTIMALLY or UNSOLVABLE_PROVEN
-        // If a plan was found, it might be reported in the `plan` field
-
         /// The engine ran out of time
         Timeout = 13,
         /// The engine ran out of memory
@@ -752,24 +794,34 @@ pub mod plan_generation_result {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Engine {
     /// Short name of the engine (planner, validator, ...)
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: ::prost::alloc::string::String,
 }
 /// Message sent by the validator.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ValidationResult {
-    #[prost(enumeration="validation_result::ValidationResultStatus", tag="1")]
+    #[prost(enumeration = "validation_result::ValidationResultStatus", tag = "1")]
     pub status: i32,
     /// Optional. Information given by the engine to the user.
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub log_messages: ::prost::alloc::vec::Vec<LogMessage>,
     /// Synthetic description of the engine that generated this message.
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub engine: ::core::option::Option<Engine>,
 }
 /// Nested message and enum types in `ValidationResult`.
 pub mod validation_result {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
     #[repr(i32)]
     pub enum ValidationResultStatus {
         /// The Plan is valid for the Problem.
@@ -794,17 +846,20 @@ pub mod validation_result {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CompilerResult {
     /// The problem generated by the Compiler
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub problem: ::core::option::Option<Problem>,
     /// The map_back_plan field is a map from the ActionInstance of the
     /// compiled problem to the original ActionInstance.
-    #[prost(map="string, message", tag="2")]
-    pub map_back_plan: ::std::collections::HashMap<::prost::alloc::string::String, ActionInstance>,
+    #[prost(map = "string, message", tag = "2")]
+    pub map_back_plan: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ActionInstance,
+    >,
     /// Optional. Information given by the engine to the user.
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub log_messages: ::prost::alloc::vec::Vec<LogMessage>,
     /// Synthetic description of the engine that generated this message.
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub engine: ::core::option::Option<Engine>,
 }
 /// The kind of an expression, which gives information related to its structure.
@@ -914,7 +969,9 @@ impl Feature {
             Feature::GeneralNumericPlanning => "GENERAL_NUMERIC_PLANNING",
             Feature::ContinuousTime => "CONTINUOUS_TIME",
             Feature::DiscreteTime => "DISCRETE_TIME",
-            Feature::IntermediateConditionsAndEffects => "INTERMEDIATE_CONDITIONS_AND_EFFECTS",
+            Feature::IntermediateConditionsAndEffects => {
+                "INTERMEDIATE_CONDITIONS_AND_EFFECTS"
+            }
             Feature::TimedEffect => "TIMED_EFFECT",
             Feature::TimedGoals => "TIMED_GOALS",
             Feature::DurationInequalities => "DURATION_INEQUALITIES",


### PR DESCRIPTION
The UP protobuf definitions can now be compiled at request as a `feature` through the following:

```bash
cargo build --features=unified_planning
```