### PR TITLE
[ci] Automate building artifacts for master branch

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = "-C target-cpu=native"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,7 +6,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  unit-tests:
     name: Unit tests
     runs-on: ubuntu-20.04
     steps:
@@ -25,7 +25,7 @@ jobs:
         with:
           command: test
 
-  fmt:
+  lints:
     name: Rustfmt and Clippy
     runs-on: ubuntu-20.04
     steps:
@@ -51,16 +51,9 @@ jobs:
           command: clippy
           args: -- -D warnings
 
-  solving:
+  integration-tests:
     name: Solving
     runs-on: ubuntu-20.04
-    env: # Make sure we have fast binaries and debuggable binaries
-      CARGO_PROFILE_RELEASE_DEBUG: false
-      CARGO_PROFILE_DEV_DEBUG: false
-      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
-      CARGO_PROFILE_DEV_OPT_LEVEL: 3
-      CARGO_PROFILE_DEV_LTO: thin
-      RUST_BACKTRACE: false
     steps:
       - name: Install protobuf
         run: sudo apt install libprotobuf-dev protobuf-compiler
@@ -86,16 +79,9 @@ jobs:
       - name: LCP Solving (PDDL & HDDL)
         run: ./ci/lcp.sh
 
-  unified_planning_api:
+  unified-planning-api:
     name: Unified Planning API
     runs-on: ubuntu-20.04
-    env: # Make sure we have fast binaries and debuggable binaries
-      CARGO_PROFILE_RELEASE_DEBUG: false
-      CARGO_PROFILE_DEV_DEBUG: false
-      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
-      CARGO_PROFILE_DEV_OPT_LEVEL: 3
-      CARGO_PROFILE_DEV_LTO: thin
-      RUST_BACKTRACE: false
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -116,7 +102,55 @@ jobs:
       - name: Check if bindings are up to date
         run: |
           printf "Checking if the API is up to date...\n"
-          cargo build --features=generate_bindings
+          cd grpc/api
+          cargo build --profile ci --features=generate_bindings
+          cd ../..
           git diff --exit-code
       - name: GRPC Server Solving
         run: python ./ci/grpc.py
+
+  pre-release:
+    name: Pre Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/deploy'   # TODO: change to master
+    # needs: [lints, units-tests, integration-tests, unified-planning-api] # TODO: ignored to speed up
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install musl toolchain
+        run: rustup target add x86_64-unknown-linux-musl
+      - name: Build release binary
+        run: | 
+          cargo build --release --target x86_64-unknown-linux-musl --bin up-server
+          mkdir -p bins/
+          cp target/x86_64-unknown-linux-musl/release/up-server bins/up-aries_linux_amd64
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            bins/up-aries_linux_amd64
+
+
+#  deploy:
+#    name: Deploy
+#
+#    runs-on: ubuntu-20.04
+#    env:
+#      CARGO_TERM_COLOR: always
+#      BUILD_TARGET: x86_64-unknown-linux-gnu
+#      BINARY_NAME: up-server
+#    steps:
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: up-aries_${{ env.BUILD_TARGET }}
+#          path: target/release/${{ env.BINARY_NAME }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Install protobuf
         run: sudo apt install libprotobuf-dev protobuf-compiler
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Install protobuf
         run: sudo apt install libprotobuf-dev protobuf-compiler
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Install protobuf
         run: sudo apt install libprotobuf-dev protobuf-compiler
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -83,7 +83,7 @@ jobs:
     name: Unified Planning API
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -99,7 +99,7 @@ jobs:
           git diff --exit-code
       - name: Install Protobuf
         run: sudo apt install -y libprotobuf-dev protobuf-compiler
-      - name: Check if bindings are up to date
+      - name: Check if generated bindings are up to date
         run: |
           printf "Checking if the API is up to date...\n"
           cd grpc/api
@@ -109,11 +109,26 @@ jobs:
       - name: GRPC Server Solving
         run: python ./ci/grpc.py
 
-  pre-release:
-    name: Pre Release
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/deploy'   # TODO: change to master
-    # needs: [lints, units-tests, integration-tests, unified-planning-api] # TODO: ignored to speed up
+
+# ================ Building & Releasing binaries.
+# Only active on the master branch and when the previous validation steps passed
+
+  build: # Build release binaries for all architecture and save them as artifacts
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        target: [amd64, arm64]
+        exclude:
+          - os: ubuntu-latest
+            target: arm64 # linux-arm64 build has linker issues, done in a distinct job
+      fail-fast: false
+    name: Build - ${{ matrix.os }} - ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    if: github.ref == 'refs/heads/deploy'
+    needs: [lints, unit-tests, integration-tests, unified-planning-api]
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout repo
         uses: actions/checkout@master
@@ -124,33 +139,116 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Install musl toolchain
-        run: rustup target add x86_64-unknown-linux-musl
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Set Environment Variables
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ] && [ "${{ matrix.target }}" == "amd64" ]; then
+            echo "TARGET=x86_64-unknown-linux-musl" >> $GITHUB_ENV
+            echo "BINARY=up-aries_linux_amd64" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "macos-latest" ] && [ "${{ matrix.target }}" == "amd64" ]; then
+            echo "TARGET=x86_64-apple-darwin" >> $GITHUB_ENV
+            echo "BINARY=up-aries_macos_amd64" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "windows-latest" ] && [ "${{ matrix.target }}" == "amd64" ]; then
+            echo "TARGET=x86_64-pc-windows-msvc" >> $GITHUB_ENV
+            echo "BINARY=up-aries_windows_amd64.exe" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "macos-latest" ] && [ "${{ matrix.target }}" == "arm64" ]; then
+            echo "TARGET=aarch64-apple-darwin" >> $GITHUB_ENV
+            echo "BINARY=up-aries_macos_arm64" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "windows-latest" ] && [ "${{ matrix.target }}" == "arm64" ]; then
+            echo "TARGET=aarch64-pc-windows-msvc" >> $GITHUB_ENV
+            echo "BINARY=up-aries_windows_arm64.exe" >> $GITHUB_ENV
+          fi
+      - name: Install toolchain
+        run: rustup target add ${{ env.TARGET }}
       - name: Build release binary
-        run: | 
-          cargo build --release --target x86_64-unknown-linux-musl --bin up-server
+        run: |
+          cargo build --release --target ${{ env.TARGET }} --bin up-server
           mkdir -p bins/
-          cp target/x86_64-unknown-linux-musl/release/up-server bins/up-aries_linux_amd64
-      - uses: "marvinpinto/action-automatic-releases@latest"
+          cp target/${{ env.TARGET }}/release/up-server bins/${{ env.BINARY }}
+      - name: Test GRPC Server Binary
+        run: |
+          if [ "${{ matrix.target }}" == "amd64" ]; then
+            # Github Actions does not support aarch64 docker images natively
+            python3 ./ci/grpc.py --executable bins/${{ env.BINARY }}
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BINARY }}
+          path: bins/${{ env.BINARY }}
+          retention-days: 1
+
+  # Build linux-aarch64 binaries in a dedicated container.
+  build-linux-arm64:
+    runs-on: ubuntu-latest
+    name: Build - ubuntu-latest - arm64
+    if: github.ref == 'refs/heads/deploy'
+    needs: [lints, unit-tests, integration-tests, unified-planning-api]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build on ubuntu-latest targetting ARM64
+        id: build
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+          dockerRunArgs: |
+            --privileged --volume "${PWD}:/workdir" --workdir /workdir
+
+          shell: /bin/bash
+          setup: mkdir -p bins/
+          install: |
+            apt-get update
+            apt-get -y upgrade
+            apt-get install -y libssl-dev libudev-dev pkg-config curl git
+            apt-get install -y build-essential gcc-aarch64-linux-gnu python3.8
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            echo $HOME/.cargo/bin >> ~/.bashrc
+            source $HOME/.cargo/env
+            rustup target add aarch64-unknown-linux-gnu
+          run: |
+            source $HOME/.cargo/env
+            cargo build --release --target aarch64-unknown-linux-gnu --bin up-server
+            cp target/aarch64-unknown-linux-gnu/release/up-server bins/up-aries_linux_arm64
+            python3.8 ./ci/grpc.py --executable bins/up-aries_linux_arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: up-aries_linux_arm64
+          path: bins/up-aries_linux_arm64
+          retention-days: 1
+
+  pre-release:  # If on master branch, Upload all artifacts as a pre-release "latest"
+    name: Pre Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/deploy'
+    needs: [build, build-linux-arm64]
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+
+      - name: Display artifacts
+        run: ls -R
+
+      - uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
           prerelease: true
           title: "Development Build"
           files: |
-            bins/up-aries_linux_amd64
-
-
-#  deploy:
-#    name: Deploy
-#
-#    runs-on: ubuntu-20.04
-#    env:
-#      CARGO_TERM_COLOR: always
-#      BUILD_TARGET: x86_64-unknown-linux-gnu
-#      BINARY_NAME: up-server
-#    steps:
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: up-aries_${{ env.BUILD_TARGET }}
-#          path: target/release/${{ env.BINARY_NAME }}
+            up-aries_linux_amd64
+            up-aries_linux_arm64
+            up-aries_macos_amd64
+            up-aries_macos_arm64
+            up-aries_windows_amd64.exe
+            up-aries_windows_arm64.exe

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.66  # stable
           override: true
       # - uses: Swatinem/rust-cache@v1
       #   with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -124,7 +124,7 @@ jobs:
       fail-fast: false
     name: Build - ${{ matrix.os }} - ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/deploy'
+    if: github.ref == 'refs/heads/master'
     needs: [lints, unit-tests, integration-tests, unified-planning-api]
     defaults:
       run:
@@ -185,7 +185,7 @@ jobs:
   build-linux-arm64:
     runs-on: ubuntu-latest
     name: Build - ubuntu-latest - arm64
-    if: github.ref == 'refs/heads/deploy'
+    if: github.ref == 'refs/heads/master'
     needs: [lints, unit-tests, integration-tests, unified-planning-api]
     steps:
       - uses: actions/checkout@v3
@@ -230,7 +230,7 @@ jobs:
   pre-release:  # If on master branch, Upload all artifacts as a pre-release "latest"
     name: Pre Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/deploy'
+    if: github.ref == 'refs/heads/master'
     needs: [build, build-linux-arm64]
     steps:
       - name: Download artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ opt-level = 0
 
 [profile.release]
 codegen-units = 8
-debug = true # Debug symbols for benchmarking
+debug = false # No debug symbols to keep executables small
 lto = "thin"
 opt-level = 3
 panic = "abort"

--- a/ci/grpc.py
+++ b/ci/grpc.py
@@ -5,12 +5,23 @@
 
 import os
 import subprocess
+import argparse
 
-build_result = os.system("cargo build --profile ci --bin up-server")
-if build_result != 0:
-    exit(1)
 
-solver = "target/ci/up-server"
+parser = argparse.ArgumentParser(description="Run GRPC server.")
+parser.add_argument("--executable", help="Path to the executable to run", default=None, nargs="?")
+
+args = parser.parse_args()
+executable = args.executable if args.executable else "target/ci/up-server"
+
+if not args.executable:
+    build_result = os.system("cargo build --profile ci --bin up-server")
+    if build_result != 0:
+        exit(1)
+
+    solver = "target/ci/up-server"
+else:
+    solver = os.path.abspath(args.executable)
 
 solver_cmd = solver + " --address 0.0.0.0:2222 --file-path {instance}"
 
@@ -21,7 +32,7 @@ instances = [
     "hierarchical_blocks_world",
     "hierarchical_blocks_world_object_as_root",
     "hierarchical_blocks_world_with_object",
-    "matchcellar"
+    "matchcellar",
 ]
 problem_files = [f"./ext/up/bins/problems/{name}.bin" for name in instances]
 


### PR DESCRIPTION
This PR attempts to automated the publication as github releases of executables for the latest commit on the master branch.
The executables should be published on the `latest` release tag: https://github.com/plaans/aries/releases/tag/latest
This is a development build so should be flagged as a pre-release.


TODO:
- [x] Add cross compilation for major platform (currently only linux-x86_64 is supported)
- [x] Only enable the `pre-release` job to run once all tests have passed (currently running immediately for facilitate testing)
- [x] Before merging, change the test in the pre-release job to only execute on the `master` (currently on `deploy` for testing purposes)