### PR TITLE
Fix: Scheduling problems with Anytime planning

### DIFF
--- a/planning/unified/plugin/up_aries/solver.py
+++ b/planning/unified/plugin/up_aries/solver.py
@@ -337,7 +337,7 @@ class Aries(AriesEngine, mixins.OneshotPlannerMixin, mixins.AnytimePlannerMixin)
         output_stream: Optional[IO[str]] = None,
     ) -> Iterator["up.engines.results.PlanGenerationResult"]:
         # Assert that the problem is a valid problem
-        assert isinstance(problem, up.model.Problem)
+        assert isinstance(problem, up.model.AbstractProblem)
 
         # start a gRPC server in its own process
         # Note: when the `server` object is garbage collected, the process will be killed


### PR DESCRIPTION
The problem came from the `assert` at the beginning of the `_get_solutions` method.

I took the opportunity to unify problem and response management between Oneshot and Anytime planning.