### PR TITLE
Align engine-internal-time metric with UP requirements

### DIFF
--- a/planning/grpc/api/src/unified_planning.proto
+++ b/planning/grpc/api/src/unified_planning.proto
@@ -844,6 +844,9 @@ message ValidationResult {
     }
     ValidationResultStatus status = 1;
 
+    // A set of engine specific values that can be reported
+    map<string, string> metrics = 4;
+
     // Optional. Information given by the engine to the user.
     repeated LogMessage log_messages = 2;
 
@@ -860,6 +863,9 @@ message CompilerResult {
     // The map_back_plan field is a map from the ActionInstance of the
     // compiled problem to the original ActionInstance.
     map<string, ActionInstance> map_back_plan = 2;
+
+    // A set of engine specific values that can be reported
+    map<string, string> metrics = 5;
 
     // Optional. Information given by the engine to the user.
     repeated LogMessage log_messages = 3;

--- a/planning/grpc/api/src/unified_planning.rs
+++ b/planning/grpc/api/src/unified_planning.rs
@@ -1036,6 +1036,12 @@ pub struct Engine {
 pub struct ValidationResult {
     #[prost(enumeration = "validation_result::ValidationResultStatus", tag = "1")]
     pub status: i32,
+    /// A set of engine specific values that can be reported
+    #[prost(map = "string, string", tag = "4")]
+    pub metrics: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
     /// Optional. Information given by the engine to the user.
     #[prost(message, repeated, tag = "2")]
     pub log_messages: ::prost::alloc::vec::Vec<LogMessage>,
@@ -1101,6 +1107,12 @@ pub struct CompilerResult {
     pub map_back_plan: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ActionInstance,
+    >,
+    /// A set of engine specific values that can be reported
+    #[prost(map = "string, string", tag = "5")]
+    pub metrics: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
     >,
     /// Optional. Information given by the engine to the user.
     #[prost(message, repeated, tag = "3")]

--- a/planning/grpc/server/src/bin/server.rs
+++ b/planning/grpc/server/src/bin/server.rs
@@ -394,6 +394,6 @@ async fn main() -> Result<(), Error> {
 fn add_engine_time(metrics: &mut HashMap<String, String>, start: &Instant) {
     metrics.insert(
         "engine_internal_time".to_string(),
-        format!("{:.3}s", start.elapsed().as_secs_f64()),
+        format!("{:.6}", start.elapsed().as_secs_f64()),
     );
 }

--- a/planning/grpc/server/src/bin/server.rs
+++ b/planning/grpc/server/src/bin/server.rs
@@ -299,6 +299,7 @@ impl UnifiedPlanning for UnifiedPlanningService {
                 println!("************* VALID *************");
                 ValidationResult {
                     status: ValidationResultStatus::Valid.into(),
+                    metrics: Default::default(),
                     log_messages: vec![],
                     engine: Some(engine()),
                 }
@@ -313,15 +314,13 @@ impl UnifiedPlanning for UnifiedPlanningService {
                 };
                 ValidationResult {
                     status: ValidationResultStatus::Invalid.into(),
+                    metrics: Default::default(),
                     log_messages: vec![log_message],
                     engine: Some(engine()),
                 }
             }
         };
-        answer.log_messages.push(LogMessage {
-            level: LogLevel::Debug as i32,
-            message: format!("engine_internal_time: {:.3}s", reception_time.elapsed().as_secs_f32()),
-        });
+        add_engine_time(&mut answer.metrics, &reception_time);
         Ok(Response::new(answer))
     }
 


### PR DESCRIPTION
- chore(up): Use new metrics field of ValidationResult
- chore(up): be more precise in engine time to avoid division by zero on UP side
