### PR TITLE
Feat: up plus & minus

### DIFF
--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -970,6 +970,17 @@ impl<'a> ChronicleFactory<'a> {
                             self.chronicle.constraints.push(Constraint::linear_eq_zero(sum));
                             Ok(value.into())
                         }
+                        "up:minus" => {
+                            ensure!(params.len() == 2, "`-` operator should have exactly 2 arguments");
+                            let value: IVar = self
+                                .create_variable(Type::UNBOUNDED_INT, VarType::Reification)
+                                .try_into()?;
+                            let sum = LinearSum::try_from(params[0])?
+                                - LinearSum::try_from(params[1])?
+                                - LinearSum::from(value);
+                            self.chronicle.constraints.push(Constraint::linear_eq_zero(sum));
+                            Ok(value.into())
+                        }
                         _ => bail!("Unsupported operator {operator}"),
                     }
                 }

--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -965,12 +965,7 @@ impl<'a> ChronicleFactory<'a> {
                                 .try_into()?;
                             let mut sum = -LinearSum::from(value);
                             for param in params {
-                                sum += match param {
-                                    Atom::Bool(_) => bail!("`+` operator with boolean parameter"),
-                                    Atom::Int(i) => LinearSum::from(i),
-                                    Atom::Fixed(f) => LinearSum::from(f),
-                                    Atom::Sym(_) => bail!("`+` operator with symbolic parameter"),
-                                };
+                                sum += LinearSum::try_from(param)?;
                             }
                             self.chronicle.constraints.push(Constraint::linear_eq_zero(sum));
                             Ok(value.into())

--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -959,6 +959,22 @@ impl<'a> ChronicleFactory<'a> {
                             self.chronicle.constraints.push(constraint);
                             Ok(value.into())
                         }
+                        "up:plus" => {
+                            let value: IVar = self
+                                .create_variable(Type::UNBOUNDED_INT, VarType::Reification)
+                                .try_into()?;
+                            let mut sum = -LinearSum::from(value);
+                            for param in params {
+                                sum += match param {
+                                    Atom::Bool(_) => bail!("`+` operator with boolean parameter"),
+                                    Atom::Int(i) => LinearSum::from(i),
+                                    Atom::Fixed(f) => LinearSum::from(f),
+                                    Atom::Sym(_) => bail!("`+` operator with symbolic parameter"),
+                                };
+                            }
+                            self.chronicle.constraints.push(Constraint::linear_eq_zero(sum));
+                            Ok(value.into())
+                        }
                         _ => bail!("Unsupported operator {operator}"),
                     }
                 }

--- a/solver/src/model/lang/linear.rs
+++ b/solver/src/model/lang/linear.rs
@@ -347,6 +347,18 @@ impl From<IAtom> for LinearSum {
     }
 }
 
+impl TryFrom<Atom> for LinearSum {
+    type Error = ConversionError;
+
+    fn try_from(value: Atom) -> Result<Self, Self::Error> {
+        match value {
+            Atom::Int(i) => Ok(LinearSum::from(i)),
+            Atom::Fixed(f) => Ok(LinearSum::from(f)),
+            _ => Err(ConversionError::TypeError),
+        }
+    }
+}
+
 impl<T: Into<LinearSum>> std::ops::Add<T> for LinearSum {
     type Output = LinearSum;
 
@@ -396,7 +408,7 @@ impl std::ops::Neg for LinearSum {
 
 use crate::transitive_conversion;
 
-use super::FAtom;
+use super::{Atom, ConversionError, FAtom};
 transitive_conversion!(LinearSum, LinearTerm, IVar);
 
 /* ========================================================================== */

--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -8,6 +8,7 @@ use crate::core::{IntCst, Lit, SignedVar, VarRef, INT_CST_MAX, INT_CST_MIN};
 use crate::create_ref_type;
 use crate::model::lang::linear::NFLinearLeq;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
+use anyhow::Context;
 use num_integer::{div_ceil, div_floor};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -154,14 +155,14 @@ impl Propagator for LinearSumLeq {
     fn propagate(&self, domains: &mut Domains, cause: Cause) -> Result<(), Contradiction> {
         if domains.entails(self.active) {
             // constraint is active, propagate
-            let sum_lb: IntCst = self
+            let sum_lb: i64 = self
                 .elements
                 .iter()
                 .copied()
                 .filter(|e| !domains.entails(!e.lit))
-                .map(|e| self.get_lower_bound(e, domains))
+                .map(|e| self.get_lower_bound(e, domains) as i64)
                 .sum();
-            let f = self.ub - sum_lb;
+            let f = (self.ub as i64) - sum_lb;
             // println!("Propagation : {} <= {}", sum_lb, self.ub);
             // self.print(domains);
             if f < 0 {
@@ -171,12 +172,14 @@ impl Propagator for LinearSumLeq {
                 return Err(Contradiction::Explanation(expl));
             }
             for &e in &self.elements {
-                let lb = self.get_lower_bound(e, domains);
-                let ub = self.get_upper_bound(e, domains);
+                let lb = self.get_lower_bound(e, domains) as i64;
+                let ub = self.get_upper_bound(e, domains) as i64;
                 debug_assert!(lb <= ub);
                 if ub - lb > f {
                     // println!("  problem on: {e:?} {lb} {ub}");
-                    match self.set_ub(e, f + lb, domains, cause) {
+                    // NOTE: Conversion from i64 to i32 should not fail due to the clamp between two i32 values.
+                    let new_ub = (f + lb).clamp(INT_CST_MIN as i64, INT_CST_MAX as i64) as i32;
+                    match self.set_ub(e, new_ub, domains, cause) {
                         Ok(true) => {} // println!("    propagated: {e:?} <= {}", f + lb),
                         Ok(false) => {}
                         Err(err) => {


### PR DESCRIPTION
Add support for `up:plus` and `up:minus` operators.

Converts `IntCst` from `i32` into `i64` in order to fix overflow issues on `LinearSumLeq` propagation. The bounds of the sum's terms are clamped into the `set_ub` method.

**NOTE**: It was not possible to have `INT_CST_MIN = i64::from(i32::MIN) - 1` (same for `INT_CST_MAX`) since the result is not a constant anymore. Therefore, I hard coded the value of the `i32::MIN` constant.