### PR TITLE
Fix: Validator

### DIFF
--- a/planning/planners/src/encode.rs
+++ b/planning/planners/src/encode.rs
@@ -1029,8 +1029,12 @@ fn encode_resource_constraints(
 
     // Force the new assigned values to be in the state variable domain.
     for &&(_, prez, eff) in &assignments {
-        let Type::Int { lb, ub } = eff.state_var.fluent.return_type() else { unreachable!() };
-        let EffectOp::Assign(val) = eff.operation else { unreachable!() };
+        let Type::Int { lb, ub } = eff.state_var.fluent.return_type() else {
+            unreachable!()
+        };
+        let EffectOp::Assign(val) = eff.operation else {
+            unreachable!()
+        };
         let val: IAtom = val.try_into().expect("Not integer assignment to an int state variable");
         solver.enforce(geq(val, lb), [prez]);
         solver.enforce(leq(val, ub), [prez]);
@@ -1046,7 +1050,9 @@ fn encode_resource_constraints(
             "Only instantaneous effects are supported"
         );
         // Get the bounds of the state variable.
-        let Type::Int { lb, ub } = eff.state_var.fluent.return_type() else { unreachable!() };
+        let Type::Int { lb, ub } = eff.state_var.fluent.return_type() else {
+            unreachable!()
+        };
         // Create a new variable with those bounds.
         let var = solver
             .model
@@ -1150,7 +1156,9 @@ fn encode_resource_constraints(
                         debug_assert!(solver.model.entails(solver.model.presence_literal(li_lit.variable())));
 
                         // Get the `ci_j*` value.
-                        let EffectOp::Increase(eff_val) = eff.operation.clone() else { unreachable!() };
+                        let EffectOp::Increase(eff_val) = eff.operation.clone() else {
+                            unreachable!()
+                        };
                         (li_lit, eff_val)
                     })
                     .collect::<Vec<_>>()

--- a/planning/planners/src/search/causal.rs
+++ b/planning/planners/src/search/causal.rs
@@ -78,7 +78,7 @@ impl SearchControl<VarLabel> for ManualCausalSearch {
             .collect();
 
         for &(tag, lig) in &self.encoding.tags {
-            let Tag::Support(cond, eff) = tag else  {continue };
+            let Tag::Support(cond, eff) = tag else { continue };
             if !pending_conditions.contains(&cond) {
                 continue;
             }

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -70,11 +70,11 @@ impl Domains {
         self.implications.add_implication(from, to);
         if self.entails(from) {
             let prop_result = self.set_impl(to, DirectOrigin::ImplicationPropagation(from));
-            assert!(matches!(prop_result, Ok(_)), "{}", "Inconsistency on the addition of implies({from:?}, {to:?}");
+            assert!(prop_result.is_ok(), "{}", "Inconsistency on the addition of implies({from:?}, {to:?}");
         }
         if self.entails(!to) {
             let prop_result = self.set_impl(!from, DirectOrigin::ImplicationPropagation(!to));
-            assert!(matches!(prop_result, Ok(_)), "{}", "Inconsistency on the addition of implies({from:?}, {to:?}");
+            assert!(prop_result.is_ok(), "{}", "Inconsistency on the addition of implies({from:?}, {to:?}");
         }
     }
 
@@ -980,6 +980,6 @@ mod tests {
         assert_eq!(model.set_ub(x, 5, Cause::Decision), Ok(true));
 
         model.save_state();
-        assert!(matches!(model.set_lb(i, 6, Cause::Decision), Err(_)));
+        assert!(model.set_lb(i, 6, Cause::Decision).is_err());
     }
 }

--- a/solver/src/model/lang/linear.rs
+++ b/solver/src/model/lang/linear.rs
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn test_sum_set_denom() {
-        let terms = vec![
+        let terms = [
             LinearTerm::constant_rational(5, 28, Lit::TRUE),
             LinearTerm::constant_rational(10, 77, Lit::TRUE),
         ];
@@ -1020,8 +1020,7 @@ mod tests {
         assert_eq!(sum.denom, 100);
 
         // Terms could have been reorganized
-        let expected_terms = vec![
-            // Constant terms without true lit, should be grouped
+        let expected_terms = [
             LinearTerm::new(45, IVar::ONE, lit1, denom),
             // Other variable terms no specificities, should be grouped by lit
             LinearTerm::new(105, var1, lit0, denom),
@@ -1224,8 +1223,7 @@ mod tests {
         assert_eq!(obj.upper_bound, -20);
 
         // Terms could have been reorganized
-        let expected_sum = vec![
-            // Constant terms without true lit, should be grouped
+        let expected_sum = [
             item(45, VarRef::ONE, lit1),
             // Other variable terms no specificities, should be grouped by lit
             item(105, var1, lit0),

--- a/solver/src/utils/mod.rs
+++ b/solver/src/utils/mod.rs
@@ -141,7 +141,7 @@ mod tests {
             println!("{x:?}");
         }
 
-        let xs = vec!["x1", "x2"];
+        let xs = ["x1", "x2"];
         let it = enumerate(vec![xs.iter()]);
         assert_eq!(it.count(), 2);
 

--- a/validator/src/interfaces/unified_planning/expression.rs
+++ b/validator/src/interfaces/unified_planning/expression.rs
@@ -261,7 +261,7 @@ impl SuffixParams for Expression {
                     .context("Parameter atom without content")?;
                 match content {
                     Content::Symbol(s) => {
-                        let mut s = s.to_owned();
+                        let mut s = s;
                         s.push('_');
                         s.push_str(suffix);
                         self.atom = Some(Atom {

--- a/validator/src/interfaces/unified_planning/mod.rs
+++ b/validator/src/interfaces/unified_planning/mod.rs
@@ -196,8 +196,14 @@ fn build_actions(problem: &Problem, plan: &Plan, verbose: bool, temporal: bool) 
     /* =========================== Utils Functions ========================== */
 
     /// Creates the span or durative action.
-    fn build_action(problem: &Problem, a: &ActionInstance, temporal: bool) -> Result<Action<Expression>> {
+    fn build_action(
+        problem: &Problem,
+        a: &ActionInstance,
+        temporal: bool,
+        default_id: String,
+    ) -> Result<Action<Expression>> {
         let pb_a = &get_pb_action(problem, a)?;
+        let id = if a.id.is_empty() { default_id } else { a.id.clone() };
 
         Ok(if temporal {
             let start = a
@@ -210,7 +216,7 @@ fn build_actions(problem: &Problem, plan: &Plan, verbose: bool, temporal: bool) 
 
             Action::Durative(DurativeAction::new(
                 a.action_name.clone(),
-                a.id.clone(),
+                id,
                 build_params(pb_a, a)?,
                 build_conditions_durative(pb_a)?,
                 build_effects_durative(pb_a)?,
@@ -230,7 +236,7 @@ fn build_actions(problem: &Problem, plan: &Plan, verbose: bool, temporal: bool) 
         } else {
             Action::Span(SpanAction::new(
                 a.action_name.clone(),
-                a.id.clone(),
+                id,
                 build_params(pb_a, a)?,
                 build_conditions_span(pb_a)?,
                 build_effects_span(pb_a)?,
@@ -341,7 +347,8 @@ fn build_actions(problem: &Problem, plan: &Plan, verbose: bool, temporal: bool) 
     ensure!(!is_schedule(problem, plan)?);
     plan.actions
         .iter()
-        .map(|a| build_action(problem, a, temporal))
+        .enumerate()
+        .map(|(i, a)| build_action(problem, a, temporal, i.to_string()))
         .collect::<Result<Vec<_>>>()
 }
 

--- a/validator/src/interfaces/unified_planning/mod.rs
+++ b/validator/src/interfaces/unified_planning/mod.rs
@@ -1183,7 +1183,7 @@ mod tests {
 
     #[test]
     fn test_is_temporal() {
-        let features = vec![Feature::ContinuousTime, Feature::DiscreteTime];
+        let features = [Feature::ContinuousTime, Feature::DiscreteTime];
         for (i, &feature) in features.iter().enumerate() {
             let mut p = problem::mock_nontemporal();
             assert!(!is_continuous_time(&p));

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -50,6 +50,11 @@ pub fn validate<E: Interpreter + SuffixParams + Clone + Display>(
     is_temporal: bool,
     min_epsilon: &Option<Rational>,
 ) -> Result<()> {
+    // Suffix all actions' parameters with the action id.
+    let mut actions = actions.to_vec();
+    actions.iter_mut().try_for_each(|a| a.suffix_params_with_id())?;
+    let actions = &actions;
+
     /* =================== Plan Analyze Without Hierarchy =================== */
     let states = if is_temporal {
         let dur_actions = actions

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -24,7 +24,7 @@ use models::{
     state::State,
     task::Task,
 };
-use traits::interpreter::Interpreter;
+use traits::{interpreter::Interpreter, suffix_params::SuffixParams};
 
 use crate::{
     models::{
@@ -41,7 +41,7 @@ const EMPTY_ACTION: &str = "__empty_action__";
 /* ========================================================================== */
 
 /// Validates a plan.
-pub fn validate<E: Interpreter + Clone + Display>(
+pub fn validate<E: Interpreter + SuffixParams + Clone + Display>(
     env: &mut Env<E>,
     actions: &[Action<E>],
     root_tasks: Option<&HashMap<String, Task<E>>>,
@@ -110,7 +110,7 @@ pub fn validate<E: Interpreter + Clone + Display>(
 /* ========================================================================== */
 
 /// Validates a non temporal plan.
-fn validate_nontemporal<E: Interpreter + Clone + Display>(
+fn validate_nontemporal<E: Interpreter + SuffixParams + Clone + Display>(
     env: &mut Env<E>,
     actions: &[SpanAction<E>],
     goals: &[SpanCondition<E>],
@@ -145,7 +145,7 @@ fn validate_nontemporal<E: Interpreter + Clone + Display>(
 /* ========================================================================== */
 
 /// Validates a temporal plan.
-fn validate_temporal<E: Interpreter + Clone + Display>(
+fn validate_temporal<E: Interpreter + SuffixParams + Clone + Display>(
     env: &mut Env<E>,
     actions: &[DurativeAction<E>],
     span_goals: &[SpanCondition<E>],
@@ -179,7 +179,7 @@ fn validate_temporal<E: Interpreter + Clone + Display>(
     }
 
     /// Adds the start and end timepoints of the condition.
-    fn add_condition_terminal<E: Interpreter + Clone + Display>(
+    fn add_condition_terminal<E: Interpreter + SuffixParams + Clone + Display>(
         condition: &DurativeCondition<E>,
         action: Option<&DurativeAction<E>>,
         env: &Env<E>,
@@ -250,7 +250,7 @@ fn validate_temporal<E: Interpreter + Clone + Display>(
     }
 
     /// Adds the given effect into the map.
-    fn add_effect<E: Interpreter + Clone + Display>(
+    fn add_effect<E: Interpreter + SuffixParams + Clone + Display>(
         effect: &DurativeEffect<E>,
         action: Option<&DurativeAction<E>>,
         env: &Env<E>,
@@ -451,7 +451,7 @@ fn validate_temporal<E: Interpreter + Clone + Display>(
 /*                                Hierarchical                                */
 /* ========================================================================== */
 
-fn validate_hierarchy<E: Clone + Display + Interpreter>(
+fn validate_hierarchy<E: Clone + Display + Interpreter + SuffixParams>(
     env: &Env<E>,
     actions: &[DurativeAction<E>],
     root_tasks: &HashMap<String, Task<E>>,
@@ -462,7 +462,7 @@ fn validate_hierarchy<E: Clone + Display + Interpreter>(
     /// Validates the action in the hierarchy:
     /// - the action must be present exactly one time in the decomposition
     /// - the decomposition must contain only actions from the plan
-    fn validate_action<E: Clone>(
+    fn validate_action<E: Clone + SuffixParams>(
         env: &Env<E>,
         action: &DurativeAction<E>,
         count_actions: &mut HashMap<String, u8>,
@@ -501,7 +501,7 @@ fn validate_hierarchy<E: Clone + Display + Interpreter>(
     /// Validates the method in the hierarchy:
     /// - each subtask must be valid
     /// - the conditions and the constraints are valid
-    fn validate_method<E: Clone + Display + Interpreter>(
+    fn validate_method<E: Clone + Display + Interpreter + SuffixParams>(
         env: &Env<E>,
         method: &Method<E>,
         count_actions: &mut HashMap<String, u8>,
@@ -594,7 +594,7 @@ fn validate_hierarchy<E: Clone + Display + Interpreter>(
 
     /// Validates the task in the hierarchy:
     /// - the refiner must be valid
-    fn validate_task<E: Clone + Display + Interpreter>(
+    fn validate_task<E: Clone + Display + Interpreter + SuffixParams>(
         env: &Env<E>,
         task: &Task<E>,
         count_actions: &mut HashMap<String, u8>,

--- a/validator/src/models/action.rs
+++ b/validator/src/models/action.rs
@@ -28,7 +28,7 @@ pub enum Action<E> {
     Durative(DurativeAction<E>),
 }
 
-impl<E: Clone + Interpreter> Action<E> {
+impl<E: Clone + Interpreter + SuffixParams> Action<E> {
     pub fn into_durative(actions: &[Action<E>]) -> Vec<DurativeAction<E>> {
         let mut c = 0;
         actions
@@ -96,6 +96,9 @@ struct BaseAction {
 }
 
 impl<E: Clone> Configurable<E> for BaseAction {
+    fn id(&self) -> &str {
+        &self.id
+    }
     fn params(&self) -> &[Parameter] {
         self.params.as_ref()
     }
@@ -134,7 +137,7 @@ pub struct SpanAction<E> {
     effects: Vec<SpanEffect<E>>,
 }
 
-impl<E: Clone + Interpreter> SpanAction<E> {
+impl<E: Clone + Interpreter + SuffixParams> SpanAction<E> {
     pub fn new(
         name: String,
         id: String,
@@ -234,13 +237,16 @@ impl<E: Clone + Interpreter> SpanAction<E> {
     }
 }
 
-impl<E: Clone> Configurable<E> for SpanAction<E> {
+impl<E: Clone + SuffixParams> Configurable<E> for SpanAction<E> {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
     fn params(&self) -> &[Parameter] {
         self.base.params.as_ref()
     }
 }
 
-impl<E: Clone + Interpreter> Act<E> for SpanAction<E> {
+impl<E: Clone + Interpreter + SuffixParams> Act<E> for SpanAction<E> {
     fn conditions(&self) -> &Vec<SpanCondition<E>> {
         &self.conditions
     }
@@ -346,7 +352,10 @@ impl<E> DurativeAction<E> {
     }
 }
 
-impl<E: Clone> Configurable<E> for DurativeAction<E> {
+impl<E: Clone + SuffixParams> Configurable<E> for DurativeAction<E> {
+    fn id(&self) -> &str {
+        &self.base.id
+    }
     fn params(&self) -> &[Parameter] {
         self.base.params.as_ref()
     }
@@ -414,6 +423,11 @@ mod tests {
         }
 
         fn convert_to_csp_constraint(&self, _: &Env<Self>) -> Result<crate::models::csp::CspConstraint> {
+            todo!()
+        }
+    }
+    impl SuffixParams for MockExpr {
+        fn suffix_params_with(&mut self, _suffix: &str) -> Result<()> {
             todo!()
         }
     }

--- a/validator/src/models/action.rs
+++ b/validator/src/models/action.rs
@@ -59,6 +59,22 @@ impl<E: Clone + Interpreter + SuffixParams> Action<E> {
     }
 }
 
+impl<E: Clone + SuffixParams> Configurable<E> for Action<E> {
+    fn id(&self) -> &str {
+        match self {
+            Action::Span(s) => s.id(),
+            Action::Durative(d) => d.id(),
+        }
+    }
+
+    fn params(&self) -> &[Parameter] {
+        match self {
+            Action::Span(s) => s.params(),
+            Action::Durative(d) => d.params(),
+        }
+    }
+}
+
 impl<E: SuffixParams> SuffixParams for Action<E> {
     fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
         match self {

--- a/validator/src/models/condition.rs
+++ b/validator/src/models/condition.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use anyhow::Result;
 
-use crate::traits::{durative::Durative, interpreter::Interpreter};
+use crate::traits::{durative::Durative, interpreter::Interpreter, suffix_params::SuffixParams};
 
 use super::{
     env::Env,
@@ -18,6 +18,15 @@ use super::{
 pub enum Condition<E: Interpreter> {
     Span(SpanCondition<E>),
     Durative(DurativeCondition<E>),
+}
+
+impl<E: Interpreter + SuffixParams> SuffixParams for Condition<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        match self {
+            Condition::Span(s) => s.suffix_params_with(suffix),
+            Condition::Durative(d) => d.suffix_params_with(suffix),
+        }
+    }
 }
 
 /* ========================================================================== */
@@ -53,6 +62,12 @@ impl<E> SpanCondition<E> {
 impl<E: Display> Display for SpanCondition<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{}", self.expr))
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for SpanCondition<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        self.expr.suffix_params_with(suffix)
     }
 }
 
@@ -119,6 +134,12 @@ impl<E> Durative<E> for DurativeCondition<E> {
 impl<E: Display> Display for DurativeCondition<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{} {}", self.interval, self.span))
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for DurativeCondition<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        self.span.suffix_params_with(suffix)
     }
 }
 

--- a/validator/src/models/effects.rs
+++ b/validator/src/models/effects.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 
 use crate::{
     print_assign,
-    traits::{act::Act, durative::Durative, interpreter::Interpreter},
+    traits::{act::Act, durative::Durative, interpreter::Interpreter, suffix_params::SuffixParams},
 };
 
 use super::{condition::SpanCondition, env::Env, state::State, time::Timepoint, value::Value};
@@ -104,6 +104,16 @@ impl<E: Display> Display for SpanEffect<E> {
     }
 }
 
+impl<E: SuffixParams> SuffixParams for SpanEffect<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        self.conditions
+            .iter_mut()
+            .try_for_each(|c| c.suffix_params_with(suffix))?;
+        self.fluent.iter_mut().try_for_each(|f| f.suffix_params_with(suffix))?;
+        self.value.suffix_params_with(suffix)
+    }
+}
+
 /* ========================================================================== */
 /*                               Durative Effect                              */
 /* ========================================================================== */
@@ -173,6 +183,12 @@ impl<E> Durative<E> for DurativeEffect<E> {
 impl<E: Display> Display for DurativeEffect<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("at {} {}", self.occurrence, self.span))
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for DurativeEffect<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        self.span.suffix_params_with(suffix)
     }
 }
 

--- a/validator/src/models/method.rs
+++ b/validator/src/models/method.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fmt::Display};
 
-use crate::traits::{configurable::Configurable, durative::Durative};
+use crate::traits::{configurable::Configurable, durative::Durative, suffix_params::SuffixParams};
 
 use super::{
     action::DurativeAction,
@@ -56,6 +56,15 @@ impl<E> Durative<E> for Subtask<E> {
         match self {
             Subtask::Action(a) => a.is_end_open(),
             Subtask::Task(t) => t.refiner().is_end_open(),
+        }
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for Subtask<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> anyhow::Result<()> {
+        match self {
+            Subtask::Action(a) => a.suffix_params_with(suffix),
+            Subtask::Task(t) => t.suffix_params_with(suffix),
         }
     }
 }
@@ -182,6 +191,21 @@ impl<E> Display for Method<E> {
                 .collect::<Vec<_>>()
                 .join(", ")
         ))
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for Method<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> anyhow::Result<()> {
+        self.params.iter_mut().try_for_each(|p| p.suffix_params_with(suffix))?;
+        self.conditions
+            .iter_mut()
+            .try_for_each(|c| c.suffix_params_with(suffix))?;
+        self.constraints
+            .iter_mut()
+            .try_for_each(|c| c.suffix_params_with(suffix))?;
+        self.subtasks
+            .iter_mut()
+            .try_for_each(|(_, s)| s.suffix_params_with(suffix))
     }
 }
 

--- a/validator/src/models/method.rs
+++ b/validator/src/models/method.rs
@@ -136,7 +136,10 @@ impl<E> Method<E> {
     }
 }
 
-impl<E: Clone> Configurable<E> for Method<E> {
+impl<E: Clone + SuffixParams> Configurable<E> for Method<E> {
+    fn id(&self) -> &str {
+        &self.id
+    }
     fn params(&self) -> &[Parameter] {
         self.params.as_ref()
     }

--- a/validator/src/models/parameter.rs
+++ b/validator/src/models/parameter.rs
@@ -29,10 +29,34 @@ impl Parameter {
     pub fn value(&self) -> &Value {
         &self.value
     }
+
+    pub fn suffix_with(&mut self, suffix: &str) {
+        let mut name = self.name.to_owned();
+        name.push('_');
+        name.push_str(suffix);
+        self.name = name;
+    }
 }
 
 impl Display for Parameter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!("{} {}({})", self.r#type, self.name, self.value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suffix_with() {
+        let mut p = Parameter::new("foo".to_string(), "tpe".to_string(), Value::Bool(true));
+        assert_eq!(p.name, "foo");
+        assert_eq!(p.r#type, "tpe");
+        assert_eq!(p.value, true.into());
+        p.suffix_with("bar");
+        assert_eq!(p.name, "foo_bar");
+        assert_eq!(p.r#type, "tpe");
+        assert_eq!(p.value, true.into());
     }
 }

--- a/validator/src/models/parameter.rs
+++ b/validator/src/models/parameter.rs
@@ -1,5 +1,9 @@
 use std::fmt::Display;
 
+use anyhow::{Ok, Result};
+
+use crate::traits::suffix_params::SuffixParams;
+
 use super::{env::Env, value::Value};
 
 /* ========================================================================== */
@@ -29,13 +33,6 @@ impl Parameter {
     pub fn value(&self) -> &Value {
         &self.value
     }
-
-    pub fn suffix_with(&mut self, suffix: &str) {
-        let mut name = self.name.to_owned();
-        name.push('_');
-        name.push_str(suffix);
-        self.name = name;
-    }
 }
 
 impl Display for Parameter {
@@ -44,19 +41,30 @@ impl Display for Parameter {
     }
 }
 
+impl SuffixParams for Parameter {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        let mut name = self.name.to_owned();
+        name.push('_');
+        name.push_str(suffix);
+        self.name = name;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn suffix_with() {
+    fn suffix_with() -> Result<()> {
         let mut p = Parameter::new("foo".to_string(), "tpe".to_string(), Value::Bool(true));
         assert_eq!(p.name, "foo");
         assert_eq!(p.r#type, "tpe");
         assert_eq!(p.value, true.into());
-        p.suffix_with("bar");
+        p.suffix_params_with("bar")?;
         assert_eq!(p.name, "foo_bar");
         assert_eq!(p.r#type, "tpe");
         assert_eq!(p.value, true.into());
+        Ok(())
     }
 }

--- a/validator/src/models/task.rs
+++ b/validator/src/models/task.rs
@@ -100,7 +100,11 @@ impl<E> Task<E> {
     }
 }
 
-impl<E: Clone> Configurable<E> for Task<E> {
+impl<E: Clone + SuffixParams> Configurable<E> for Task<E> {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
     fn params(&self) -> &[Parameter] {
         self.params.as_ref()
     }

--- a/validator/src/models/task.rs
+++ b/validator/src/models/task.rs
@@ -1,4 +1,4 @@
-use crate::traits::{configurable::Configurable, durative::Durative};
+use crate::traits::{configurable::Configurable, durative::Durative, suffix_params::SuffixParams};
 
 use super::{action::DurativeAction, method::Method, parameter::Parameter};
 
@@ -51,6 +51,15 @@ impl<E> Durative<E> for Refiner<E> {
     }
 }
 
+impl<E: SuffixParams> SuffixParams for Refiner<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> anyhow::Result<()> {
+        match self {
+            Refiner::Method(m) => m.suffix_params_with(suffix),
+            Refiner::Action(a) => a.suffix_params_with(suffix),
+        }
+    }
+}
+
 /* ========================================================================== */
 /*                                    Task                                    */
 /* ========================================================================== */
@@ -94,5 +103,12 @@ impl<E> Task<E> {
 impl<E: Clone> Configurable<E> for Task<E> {
     fn params(&self) -> &[Parameter] {
         self.params.as_ref()
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for Task<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> anyhow::Result<()> {
+        self.params.iter_mut().try_for_each(|p| p.suffix_params_with(suffix))?;
+        self.refiner.suffix_params_with(suffix)
     }
 }

--- a/validator/src/models/time.rs
+++ b/validator/src/models/time.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use malachite::Rational;
 
-use crate::traits::{durative::Durative, interpreter::Interpreter};
+use crate::traits::{durative::Durative, interpreter::Interpreter, suffix_params::SuffixParams};
 use anyhow::{bail, Result};
 
 use super::env::Env;
@@ -269,6 +269,13 @@ impl<E: Display> Display for TemporalIntervalExpression<E> {
         let lb = if self.is_start_open { "]" } else { "[" };
         let ub = if self.is_end_open { "[" } else { "]" };
         f.write_fmt(format_args!("{}{}, {}{}", lb, self.start, self.end, ub))
+    }
+}
+
+impl<E: SuffixParams> SuffixParams for TemporalIntervalExpression<E> {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()> {
+        self.start.suffix_params_with(suffix)?;
+        self.end.suffix_params_with(suffix)
     }
 }
 

--- a/validator/src/procedures.rs
+++ b/validator/src/procedures.rs
@@ -12,17 +12,11 @@ use anyhow::{bail, ensure, Context, Result};
 pub type Procedure<E> = fn(&Env<E>, Vec<E>) -> Result<Value>;
 
 pub fn and<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
-    args.iter().fold(Ok(true.into()), |r, a| match r {
-        Ok(b) => b & a.eval(env)?,
-        Err(e) => Err(e),
-    })
+    args.iter().try_fold(true.into(), |r, a| r & a.eval(env)?)
 }
 
 pub fn or<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
-    args.iter().fold(Ok(false.into()), |r, a| match r {
-        Ok(b) => b | a.eval(env)?,
-        Err(e) => Err(e),
-    })
+    args.iter().try_fold(false.into(), |r, a| r | a.eval(env)?)
 }
 
 pub fn not<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {

--- a/validator/src/traits/configurable.rs
+++ b/validator/src/traits/configurable.rs
@@ -1,7 +1,10 @@
 use crate::models::{env::Env, parameter::Parameter};
 
+use super::suffix_params::SuffixParams;
+
 /// Represents a struct that can extend the environment with parameters.
-pub trait Configurable<E: Clone> {
+pub trait Configurable<E: Clone>: SuffixParams {
+    fn id(&self) -> &str;
     fn params(&self) -> &[Parameter];
     fn new_env_with_params(&self, env: &Env<E>) -> Env<E> {
         let mut new_env = env.clone();
@@ -9,5 +12,9 @@ pub trait Configurable<E: Clone> {
             param.bound(&mut new_env);
         }
         new_env
+    }
+    fn suffix_params_with_id(&mut self) -> anyhow::Result<()> {
+        let id = self.id().to_string();
+        self.suffix_params_with(&id)
     }
 }

--- a/validator/src/traits/mod.rs
+++ b/validator/src/traits/mod.rs
@@ -2,4 +2,5 @@ pub mod act;
 pub mod configurable;
 pub mod durative;
 pub mod interpreter;
+pub mod suffix_params;
 pub mod typeable;

--- a/validator/src/traits/suffix_params.rs
+++ b/validator/src/traits/suffix_params.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+/// Represents a struct containing parameters which can be suffixed.
+pub trait SuffixParams {
+    fn suffix_params_with(&mut self, suffix: &str) -> Result<()>;
+}


### PR DESCRIPTION
## Validator fixes

- Give a default id to UPF actions
- Suffix all actions' parameters with the action id

## Other modification

- `cargo fmt` and `cargo clippy`