### PR TITLE
feat(cp): Improve efficiency of linear constraints propagation

### DIFF
--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -472,8 +472,8 @@ mod tests {
     /* =============================== Helpers ============================== */
 
     fn check_bounds(s: &LinearSumLeq, e: SumElem, d: &Domains, lb: IntCst, ub: IntCst) {
-        assert_eq!(s.get_lower_bound(e, d), lb);
-        assert_eq!(s.get_upper_bound(e, d), ub);
+        assert_eq!(s.get_lower_bound(e, d), lb.into());
+        assert_eq!(s.get_upper_bound(e, d), ub.into());
     }
 
     fn check_bounds_var(v: VarRef, d: &Domains, lb: IntCst, ub: IntCst) {

--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -131,6 +131,7 @@ impl LinearSumLeq {
 
 impl Propagator for LinearSumLeq {
     fn setup(&self, id: PropagatorId, context: &mut Watches) {
+        context.add_watch(self.active.variable(), id);
         for e in &self.elements {
             if !e.is_constant() {
                 context.add_watch(e.var, id);
@@ -163,7 +164,7 @@ impl Propagator for LinearSumLeq {
                 let ub = self.get_upper_bound(e, domains);
                 debug_assert!(lb <= ub);
                 if ub - lb > f {
-                    let new_ub = (f + lb);
+                    let new_ub = f + lb;
                     match self.set_ub(e, new_ub, domains, cause) {
                         Ok(true) => {}  // domain updated
                         Ok(false) => {} // no-op


### PR DESCRIPTION
- feat(cp): Reactivate watch-based propagation of linear constraints.
- chore(cp): Make watches on VarRef (less error prone than SVar)
- feat(cp): Only trigger propagation once per constraint.
- chore(cp): Clean up internal conversions from/to i64.
