### PR TITLE
Async issue: workaround

### DIFF
--- a/planning/grpc/server/src/bin/server.rs
+++ b/planning/grpc/server/src/bin/server.rs
@@ -265,6 +265,10 @@ impl UnifiedPlanning for UnifiedPlanningService {
                     eprintln!("Could not send intermediate solution through the gRPC channel.");
                 }
             });
+            // FIXME
+            //  This empty call is used to be sure that the previous one is called.
+            //  It may be caused by the interaction between the OS threads and the tokio tasks.
+            tokio::spawn(async move {});
         };
 
         // run a new green thread in which the solver will run


### PR DESCRIPTION
Temporary correction of an asynchronous problem in the UPF link: the last plan is not sent.

Hint of research for a real fix: [here](https://stackoverflow.com/questions/77143048/why-does-tokio-run-only-n-1-of-n-tasks-when-called-in-a-weird-wayl)