### PR TITLE
feat(up): Support default values in UP planning problems

### DIFF
--- a/planning/grpc/server/src/bin/server.rs
+++ b/planning/grpc/server/src/bin/server.rs
@@ -147,7 +147,7 @@ fn solve_blocking(
     ensure!(problem.metrics.len() <= 1, "Unsupported: multiple metrics provided.");
     let metric = if !conf.optimal {
         None
-    } else if let Some(metric) = problem.metrics.get(0) {
+    } else if let Some(metric) = problem.metrics.first() {
         match up::metric::MetricKind::from_i32(metric.kind) {
             Some(MetricKind::MinimizeActionCosts) => Some(Metric::ActionCosts),
             Some(MetricKind::MinimizeSequentialPlanLength) => Some(Metric::PlanLength),

--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -1026,7 +1026,7 @@ impl<'a> ChronicleFactory<'a> {
                         params.len() <= 1,
                         "Too many parameters for temporal qualifier: {operator}"
                     );
-                    let timepoint = if let Some(param) = params.get(0) {
+                    let timepoint = if let Some(param) = params.first() {
                         // we must have something of the form `up:start(task_id)` or `up:end(task_id)`
                         ensure!(kind(param)? == ExpressionKind::ContainerId);
                         let container = match param.atom.as_ref().unwrap().content.as_ref().unwrap() {

--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -416,7 +416,7 @@ fn read_init_fact(fact: &up::Assignment, symbols: &SymbolTable) -> anyhow::Resul
     };
 
     // first symbol as the fluent, the rest are the parameters
-    ensure!(fluent.list.len() > 0, "Malformed fluent expression: {fluent:?}");
+    ensure!(!fluent.list.is_empty(), "Malformed fluent expression: {fluent:?}");
     let fluent_sym = atom_to_symid(
         fluent.list[0]
             .atom

--- a/planning/grpc/server/src/chronicles.rs
+++ b/planning/grpc/server/src/chronicles.rs
@@ -3,14 +3,16 @@ use aries::core::{IntCst, Lit, INT_CST_MAX, INT_CST_MIN};
 use aries::model::extensions::Shaped;
 use aries::model::lang::linear::LinearSum;
 use aries::model::lang::*;
-use aries::model::symbols::SymbolTable;
-use aries::model::types::TypeHierarchy;
+use aries::model::symbols::{SymId, SymbolTable};
+use aries::model::types::{TypeHierarchy, TypeId};
+use aries::utils::enumerate;
 use aries::utils::input::Sym;
 use aries_planning::chronicles::constraints::{Constraint, ConstraintType, Duration};
 use aries_planning::chronicles::VarType::Reification;
 use aries_planning::chronicles::*;
 use aries_planning::parsing::pddl::TypedSymbol;
 use env_param::EnvParam;
+use itertools::Itertools;
 use regex::Regex;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
@@ -218,7 +220,7 @@ pub fn problem_to_chronicles(problem: &Problem) -> Result<aries_planning::chroni
 
     let mut factory = ChronicleFactory::new(&mut context, init_ch, Container::Base, vec![]);
 
-    factory.add_initial_state(&problem.initial_state)?;
+    factory.add_initial_state(&problem.initial_state, &problem.fluents)?;
     factory.add_timed_effects(&problem.timed_effects)?;
     factory.add_goals(&problem.goals)?;
 
@@ -325,7 +327,7 @@ fn scheduling_problem_to_chronicles(
     // it must used as a context for all expression evaluations
     let global_env = factory.env.clone();
 
-    factory.add_initial_state(&problem.initial_state)?;
+    factory.add_initial_state(&problem.initial_state, &problem.fluents)?;
     factory.add_timed_effects(&problem.timed_effects)?;
     factory.add_goals(&problem.goals)?;
 
@@ -358,6 +360,13 @@ struct ActionCosts {
     default: Option<Expression>,
 }
 
+fn atom_to_symid(atom: &up::Atom, symbols: &SymbolTable) -> anyhow::Result<SymId> {
+    let Some(Content::Symbol(s)) = &atom.content else {
+        bail!("No symbolic content in atom: {atom:?}");
+    };
+    symbols.id(s).with_context(|| format!("Unknown symbol: {s:?}"))
+}
+
 fn str_to_symbol(name: &str, symbol_table: &SymbolTable) -> anyhow::Result<SAtom> {
     let sym = symbol_table
         .id(name)
@@ -382,6 +391,50 @@ fn read_atom(atom: &up::Atom, symbol_table: &SymbolTable) -> Result<aries::model
     } else {
         bail!("Unsupported atom")
     }
+}
+
+struct InitFact {
+    fluent: SymId,
+    params: Vec<SymId>,
+    value: Atom,
+}
+
+fn read_init_fact(fact: &up::Assignment, symbols: &SymbolTable) -> anyhow::Result<InitFact> {
+    let get_atom = |e: &up::Expression| {
+        let atom = e.atom.as_ref().with_context(|| format!("Not an atom: {e:?}"))?;
+        read_atom(atom, symbols)
+    };
+    let get_sym = |e: &up::Expression| {
+        let atom = e.atom.as_ref().with_context(|| format!("Not an atom: {e:?}"))?;
+        match atom.content.as_ref() {
+            Some(up::atom::Content::Symbol(s)) => symbols.id(s).with_context(|| format!("Unknown symbol: {:?}", s)),
+            _ => bail!("Not a symbol {:?}", e),
+        }
+    };
+    let Some(fluent) = fact.fluent.as_ref() else {
+        bail!("Malformed init fact: {fact:?}")
+    };
+
+    // first symbol as the fluent, the rest are the parameters
+    ensure!(fluent.list.len() > 0, "Malformed fluent expression: {fluent:?}");
+    let fluent_sym = atom_to_symid(
+        fluent.list[0]
+            .atom
+            .as_ref()
+            .with_context(|| format!("Missing fluent atom : {:?}", fluent))?,
+        symbols,
+    )?;
+    let params: Vec<SymId> = fluent.list[1..].iter().map(get_sym).try_collect()?;
+
+    let Some(value) = fact.value.as_ref() else {
+        bail!("Malformed init fact: {fact:?}")
+    };
+    let value = get_atom(value)?;
+    Ok(InitFact {
+        fluent: fluent_sym,
+        params,
+        value,
+    })
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -565,20 +618,86 @@ impl<'a> ChronicleFactory<'a> {
     }
 
     /// Converts initial state to a set of effects at the start time
-    fn add_initial_state(&mut self, init_state: &[Assignment]) -> Result<(), Error> {
-        for assignment in init_state {
-            let state_var = assignment
-                .fluent
-                .as_ref()
-                .context("Initial state assignment has no valid fluent")?;
-            let value = assignment
-                .value
-                .as_ref()
-                .context("Initial state assignment has no valid value")?;
-            let init_time = Span::instant(self.chronicle.start);
-
-            self.add_effect(init_time, state_var, value, EffectKind::Assign)?;
+    fn add_initial_state(&mut self, init_state: &[Assignment], fluents: &[up::Fluent]) -> Result<(), Error> {
+        let mut explicit_init_facts = Vec::with_capacity(init_state.len());
+        for init_assignment in init_state {
+            explicit_init_facts.push(read_init_fact(init_assignment, &self.context.model.shape.symbols)?)
         }
+
+        for up_fluent in fluents {
+            let symbols = self.context.model.get_symbol_table();
+            let fluent_sym = symbols
+                .id(&up_fluent.name)
+                .with_context(|| format!("Unknown symbol: {}", up_fluent.name))?;
+            let fluent = self
+                .context
+                .fluents
+                .iter()
+                .find(|f| f.sym == fluent_sym)
+                .with_context(|| format!("No such fluent: {}", up_fluent.name))?
+                .clone();
+
+            if let Some(default) = &up_fluent.default_value {
+                // fluent has a default value
+                let default = read_atom(
+                    default
+                        .atom
+                        .as_ref()
+                        .with_context(|| format!("Not an atom in default fluent value: {:?}", up_fluent))?,
+                    symbols,
+                )?;
+
+                // gather all values that are explicitly set for this fluent
+                let mut explicit_values: HashMap<&[SymId], Atom> = Default::default();
+                for fact in &explicit_init_facts {
+                    if fact.fluent == fluent_sym {
+                        explicit_values.insert(&fact.params, fact.value);
+                    }
+                }
+
+                // build an iterator over all combinations of values for the fluent's parameters
+                let arg_types: Vec<TypeId> = fluent
+                    .argument_types()
+                    .iter()
+                    .map(|tpe| TypeId::try_from(*tpe))
+                    .try_collect()
+                    .context("unsupported non symbolic type in fluent parameters")?;
+                let arg_domains = arg_types.iter().map(|tpe| symbols.instances_of_type(*tpe)).collect();
+                use aries::utils::StreamingIterator;
+                let mut combinations = enumerate(arg_domains);
+
+                // for each possible instantiation of the fluent add an initial fact (with a default)
+                while let Some(comb) = combinations.next() {
+                    let value = explicit_values.get(comb).unwrap_or(&default);
+                    self.add_init_fact(fluent.clone(), comb, *value)?;
+                }
+            } else {
+                // no default value for fluent, only put the value explicitly stated
+                for explicit_fact in &explicit_init_facts {
+                    if explicit_fact.fluent == fluent_sym {
+                        self.add_init_fact(fluent.clone(), &explicit_fact.params, explicit_fact.value)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn add_init_fact(&mut self, fluent: Arc<Fluent>, args: &[SymId], value: Atom) -> anyhow::Result<()> {
+        let args = args
+            .iter()
+            .map(|&sym| SAtom::new_constant(sym, self.context.model.get_symbol_table().type_of(sym)))
+            .collect();
+        let sv = StateVar { fluent, args };
+
+        self.chronicle.effects.push(Effect {
+            transition_start: self.context.origin(),
+            transition_end: self.context.origin(),
+            min_mutex_end: vec![],
+            state_var: sv,
+            operation: EffectOp::Assign(value),
+        });
         Ok(())
     }
 

--- a/planning/grpc/server/src/serialize.rs
+++ b/planning/grpc/server/src/serialize.rs
@@ -50,7 +50,7 @@ pub fn serialize_plan(
         let end = serialize_time(ch.chronicle.end, assignment)?;
 
         // extract name and parameters (possibly empty if not an action or method chronicle)
-        let name = if let Some(name) = ch.chronicle.name.get(0) {
+        let name = if let Some(name) = ch.chronicle.name.first() {
             let name = SAtom::try_from(*name).context("Action name is not a symbol")?;
             let name = assignment.sym_value_of(name).context("Unbound sym var")?;
             problem.model.shape.symbols.symbol(name).to_string()

--- a/planning/unified/scripts/cli.py
+++ b/planning/unified/scripts/cli.py
@@ -17,6 +17,7 @@ parser.add_argument("-s", "--solver", default="aries", )
 parser.add_argument("-m", "--mode", default="solve")
 parser.add_argument("-o", "--outfile", default="/tmp/problem.upp")
 parser.add_argument("--timeout", default="1800")
+parser.add_argument('-f', '--from-file', action='store_true')
 parser.add_argument("problem_name")
 
 
@@ -25,30 +26,51 @@ print(args)
 
 
 packages = ["builtin", "unified_planning.test"]
-problem_test_cases = get_test_cases_from_packages(packages)
 
 
-test_case = problem_test_cases[args.problem_name]
+if args.from_file:
+    # reads from a protobuf file
+    with open(args.problem_name, "rb") as file:
+        content = file.read()
+        pb_msg = proto.Problem()
+        pb_msg.ParseFromString(content)
+    reader = ProtobufReader()
+    problem = reader.convert(pb_msg)
+else:
+    problem_test_cases = get_test_cases_from_packages(packages)
+    test_case = problem_test_cases[args.problem_name]
+    problem = test_case.problem
 
 if args.mode == "solve":
     print("SOLVING")
-    # with OneshotPlanner(name=args.solver) as planner:
-    #     result = planner.solve(test_case.problem, output_stream=sys.stdout)
-    #
-    #     print(result)
-    with AnytimePlanner(name=args.solver) as planner:
-        for r in planner.get_solutions(test_case.problem, timeout=float(args.timeout), output_stream=sys.stdout):
-            print(r)
-            print("\n===================\n")
 
-        # print(result)
+    print(problem.kind)
+    print(problem)
+
+    plan = None
+    try:
+        with AnytimePlanner(name=args.solver) as planner:
+            for r in planner.get_solutions(problem, timeout=float(args.timeout), output_stream=sys.stdout):
+                print(r)
+                plan = r.plan
+                print("\n===================\n")
+    except AssertionError:
+        with OneshotPlanner(name=args.solver) as planner:
+            result = planner.solve(problem, output_stream=sys.stdout)
+            plan = result.plan
+            print(result)
+
+    with PlanValidator(problem_kind=problem.kind) as validator:
+        val_result = validator.validate(problem, plan)
+        print(val_result)
 
 elif args.mode == "dump":
+    print(problem)
     print(f"Dumping problem to {args.outfile}")
     print(test_case.problem)
 
     writer = ProtobufWriter()
-    msg = writer.convert(test_case.problem)
+    msg = writer.convert(problem)
     with open(args.outfile, "wb") as file:
         file.write(msg.SerializeToString())
 

--- a/solver/src/model/types.rs
+++ b/solver/src/model/types.rs
@@ -1,9 +1,10 @@
 use crate::collections::id_map::IdMap;
 use crate::collections::ref_store::RefPool;
+use crate::model::lang::Type;
 use crate::utils::input::Sym;
 use std::borrow::Borrow;
 use std::error::Error;
-use std::fmt::{Debug, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
 // Todo: use Ref
@@ -18,6 +19,32 @@ impl From<TypeId> for usize {
 impl From<usize> for TypeId {
     fn from(id: usize) -> Self {
         TypeId(id)
+    }
+}
+
+pub struct NotASymbolicType(Type);
+
+impl Debug for NotASymbolicType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Not a symbolic type: {:?}", self.0)
+    }
+}
+
+impl Display for NotASymbolicType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+impl std::error::Error for NotASymbolicType {}
+
+impl TryFrom<Type> for TypeId {
+    type Error = NotASymbolicType;
+
+    fn try_from(value: Type) -> Result<Self, Self::Error> {
+        match value {
+            Type::Sym(t) => Ok(t),
+            _ => Err(NotASymbolicType(value)),
+        }
     }
 }
 

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -210,7 +210,7 @@ impl<Lbl: Label> Solver<Lbl> {
                         }
                     }
                     2 => {
-                        let fst = lin.sum.get(0).unwrap();
+                        let fst = lin.sum.first().unwrap();
                         let snd = lin.sum.get(1).unwrap();
                         debug_assert_ne!(fst.factor, 0);
                         debug_assert_ne!(snd.factor, 0);

--- a/validator/src/interfaces/unified_planning/expression.rs
+++ b/validator/src/interfaces/unified_planning/expression.rs
@@ -212,21 +212,21 @@ impl Interpreter for Expression {
                     UP_LT => {
                         check_args(&args, 2, &p)?;
                         CspConstraint::Lt(
-                            into_csp_term(args.get(0).unwrap(), env)?,
+                            into_csp_term(args.first().unwrap(), env)?,
                             into_csp_term(args.get(1).unwrap(), env)?,
                         )
                     }
                     UP_LE => {
                         check_args(&args, 2, &p)?;
                         CspConstraint::Le(
-                            into_csp_term(args.get(0).unwrap(), env)?,
+                            into_csp_term(args.first().unwrap(), env)?,
                             into_csp_term(args.get(1).unwrap(), env)?,
                         )
                     }
                     UP_EQUALS => {
                         check_args(&args, 2, &p)?;
                         CspConstraint::Equals(
-                            into_csp_term(args.get(0).unwrap(), env)?,
+                            into_csp_term(args.first().unwrap(), env)?,
                             into_csp_term(args.get(1).unwrap(), env)?,
                         )
                     }
@@ -445,7 +445,7 @@ mod tests {
     #[test]
     fn eval_function_application() -> Result<()> {
         fn proc(env: &Env<Expression>, args: Vec<Expression>) -> Result<Value> {
-            let a1 = args.get(0).unwrap().eval(env)?;
+            let a1 = args.first().unwrap().eval(env)?;
             let a2 = args.get(1).unwrap().eval(env)?;
             (!a1)? & a2
         }

--- a/validator/src/interfaces/unified_planning/factories.rs
+++ b/validator/src/interfaces/unified_planning/factories.rs
@@ -597,7 +597,7 @@ pub mod problem {
             )],
             initial_state: vec![Assignment {
                 fluent: Some(expression::state_variable(vec![
-                    expression::fluent_symbol(loc_fluent),
+                    expression::fluent_symbol(&format!("{} -- {}", loc_fluent, loc_type)),
                     expression::parameter(r1, robot_type),
                 ])),
                 value: Some(expression::symbol(loc1, loc_type)),

--- a/validator/src/interfaces/unified_planning/factories.rs
+++ b/validator/src/interfaces/unified_planning/factories.rs
@@ -1,6 +1,10 @@
-use unified_planning::{atom::Content, effect_expression::EffectKind, *};
+#[cfg(test)]
+use super::constants::{UP_BOOL, UP_CONTAINER, UP_END, UP_EQUALS, UP_REAL, UP_START};
+#[cfg(test)]
+use unified_planning::effect_expression::EffectKind;
 
-use super::constants::{UP_BOOL, UP_CONTAINER, UP_END, UP_EQUALS, UP_INTEGER, UP_REAL, UP_START};
+use super::constants::UP_INTEGER;
+use unified_planning::{atom::Content, *};
 
 /* ========================================================================== */
 /*                                   Content                                  */
@@ -9,15 +13,21 @@ use super::constants::{UP_BOOL, UP_CONTAINER, UP_END, UP_EQUALS, UP_INTEGER, UP_
 pub mod content {
     use super::*;
 
+    #[cfg(test)]
     pub fn symbol(s: &str) -> Content {
         Content::Symbol(s.into())
     }
+
     pub fn int(i: i64) -> Content {
         Content::Int(i)
     }
+
+    #[cfg(test)]
     pub fn real(numerator: i64, denominator: i64) -> Content {
         Content::Real(Real { numerator, denominator })
     }
+
+    #[cfg(test)]
     pub fn boolean(b: bool) -> Content {
         Content::Boolean(b)
     }
@@ -27,6 +37,7 @@ pub mod content {
 /*                                   Action                                   */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod action {
     use super::*;
 
@@ -57,6 +68,7 @@ pub mod action {
 /*                                  Activity                                  */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod activity {
     use super::*;
 
@@ -83,6 +95,7 @@ pub mod activity {
 /*                                  Condition                                 */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod condition {
     use super::*;
 
@@ -104,6 +117,7 @@ pub mod condition {
 /*                                  Duration                                  */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod duration {
     use super::*;
 
@@ -123,6 +137,7 @@ pub mod duration {
 /*                                   Effect                                   */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod effect {
     use super::*;
 
@@ -182,6 +197,7 @@ pub mod effect {
 pub mod expression {
     use super::*;
 
+    #[cfg(test)]
     pub fn unknown() -> Expression {
         Expression {
             kind: ExpressionKind::Unknown.into(),
@@ -198,6 +214,7 @@ pub mod expression {
         }
     }
 
+    #[cfg(test)]
     pub fn list(list: Vec<Expression>, k: ExpressionKind) -> Expression {
         Expression {
             list,
@@ -210,6 +227,7 @@ pub mod expression {
         atom(c, t, ExpressionKind::Constant)
     }
 
+    #[cfg(test)]
     pub fn symbol(s: &str, t: &str) -> Expression {
         constant(super::content::symbol(s), t)
     }
@@ -218,14 +236,17 @@ pub mod expression {
         constant(super::content::int(i), UP_INTEGER)
     }
 
+    #[cfg(test)]
     pub fn int_bounded(i: i64, lb: i64, ub: i64) -> Expression {
         constant(super::content::int(i), &format!("{UP_INTEGER}[{lb}, {ub}]"))
     }
 
+    #[cfg(test)]
     pub fn real(numerator: i64, denominator: i64) -> Expression {
         constant(super::content::real(numerator, denominator), UP_REAL)
     }
 
+    #[cfg(test)]
     pub fn real_bounded(numerator: i64, denominator: i64, lb: i64, ub: i64) -> Expression {
         constant(
             super::content::real(numerator, denominator),
@@ -233,46 +254,57 @@ pub mod expression {
         )
     }
 
+    #[cfg(test)]
     pub fn boolean(b: bool) -> Expression {
         constant(super::content::boolean(b), UP_BOOL)
     }
 
+    #[cfg(test)]
     pub fn parameter(s: &str, t: &str) -> Expression {
         atom(super::content::symbol(s), t, ExpressionKind::Parameter)
     }
 
+    #[cfg(test)]
     pub fn variable(t: &str, n: &str) -> Expression {
         atom(super::content::symbol(n), t, ExpressionKind::Variable)
     }
 
+    #[cfg(test)]
     pub fn fluent_symbol(s: &str) -> Expression {
         atom(super::content::symbol(s), "", ExpressionKind::FluentSymbol)
     }
 
+    #[cfg(test)]
     pub fn fluent_symbol_with_type(s: &str, t: &str) -> Expression {
         atom(super::content::symbol(s), t, ExpressionKind::FluentSymbol)
     }
 
+    #[cfg(test)]
     pub fn function_symbol(s: &str) -> Expression {
         atom(super::content::symbol(s), "", ExpressionKind::FunctionSymbol)
     }
 
+    #[cfg(test)]
     pub fn state_variable(args: Vec<Expression>) -> Expression {
         list(args, ExpressionKind::StateVariable)
     }
 
+    #[cfg(test)]
     pub fn function_application(args: Vec<Expression>) -> Expression {
         list(args, ExpressionKind::FunctionApplication)
     }
 
+    #[cfg(test)]
     pub fn container_id(c: &str) -> Expression {
         atom(content::symbol(c), UP_CONTAINER, ExpressionKind::ContainerId)
     }
 
+    #[cfg(test)]
     pub fn end_of(c: &str) -> Expression {
         function_application(vec![function_symbol(UP_END), container_id(c)])
     }
 
+    #[cfg(test)]
     pub fn start_of(c: &str) -> Expression {
         function_application(vec![function_symbol(UP_START), container_id(c)])
     }
@@ -282,6 +314,7 @@ pub mod expression {
 /*                                   Fluent                                   */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod fluent {
     use super::*;
 
@@ -299,6 +332,7 @@ pub mod fluent {
 /*                                   Object                                   */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod object {
     use super::*;
 
@@ -314,6 +348,7 @@ pub mod object {
 /*                                  Parameter                                 */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod parameter {
     use super::*;
 
@@ -329,6 +364,7 @@ pub mod parameter {
 /*                                   Timing                                   */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod timing {
     use unified_planning::timepoint::TimepointKind;
 
@@ -379,6 +415,7 @@ pub mod timing {
 /*                                Time Interval                               */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod time_interval {
     use super::*;
 
@@ -404,6 +441,7 @@ pub mod time_interval {
 /*                                    Plan                                    */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod plan {
     use std::collections::HashMap;
 
@@ -491,6 +529,7 @@ pub mod plan {
 /*                                   Problem                                  */
 /* ========================================================================== */
 
+#[cfg(test)]
 pub mod problem {
     use std::vec;
 

--- a/validator/src/interfaces/unified_planning/mod.rs
+++ b/validator/src/interfaces/unified_planning/mod.rs
@@ -882,7 +882,7 @@ mod tests {
         e.bound("location".into(), "L2".into(), "L2".into());
 
         // Fluents
-        e.bound_fluent(vec!["loc".into(), "R1".into()], "L1".into())?;
+        e.bound_fluent(vec!["loc -- location".into(), "R1".into()], "L1".into())?;
 
         // Procedures
         e.bound_procedure(UP_AND.into(), procedures::and);

--- a/validator/src/macros.rs
+++ b/validator/src/macros.rs
@@ -27,3 +27,23 @@ macro_rules! print_assign {
         }
     };
 }
+
+#[macro_export]
+macro_rules! print_warn {
+    ($v:expr, $($arg:tt)*) => {
+        if $v == true {
+            print!("\x1b[93m[WARN]\x1b[0m ");
+            println!($($arg)*);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! print_debug {
+    ($v:expr, $($arg:tt)*) => {
+        if $v == true {
+            print!("\x1b[94m[DEBUG]\x1b[0m ");
+            println!($($arg)*);
+        }
+    };
+}

--- a/validator/src/procedures.rs
+++ b/validator/src/procedures.rs
@@ -26,14 +26,14 @@ pub fn not<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
 
 pub fn implies<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     (!a)? | b
 }
 
 pub fn equals<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     Ok((a == b).into())
 }
@@ -44,7 +44,7 @@ pub fn le<E: Interpreter + Clone>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
 
 pub fn lt<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     Ok(match a {
         Value::Number(v1, _, _) => match b {
@@ -57,35 +57,35 @@ pub fn lt<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
 
 pub fn plus<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     a + b
 }
 
 pub fn minus<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     a - b
 }
 
 pub fn times<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     a * b
 }
 
 pub fn div<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     a / b
 }
 
 pub fn exists<E: Clone + Interpreter + Typeable>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let v = args.get(0).unwrap();
+    let v = args.first().unwrap();
     let e = args.get(1).unwrap();
     for o in env
         .get_objects(&v.tpe())
@@ -106,7 +106,7 @@ pub fn exists<E: Clone + Interpreter + Typeable>(env: &Env<E>, args: Vec<E>) -> 
 
 pub fn forall<E: Interpreter + Clone + Typeable>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let v = args.get(0).unwrap();
+    let v = args.first().unwrap();
     let e = args.get(1).unwrap();
     for o in env
         .get_objects(&v.tpe())
@@ -127,7 +127,7 @@ pub fn forall<E: Interpreter + Clone + Typeable>(env: &Env<E>, args: Vec<E>) -> 
 
 pub fn iff<E: Interpreter>(env: &Env<E>, args: Vec<E>) -> Result<Value> {
     ensure!(args.len() == 2);
-    let a = args.get(0).unwrap().eval(env)?;
+    let a = args.first().unwrap().eval(env)?;
     let b = args.get(1).unwrap().eval(env)?;
     Ok(match a {
         Value::Bool(v1) => match b {


### PR DESCRIPTION
This PR adds support for default parameters in UP problems. Previously we made the assumption that all initial values were provided in the int_values, which may not hold in the future.

@Shi-Raida could you add support for this in the validator as well. This PR uses a branch of the UP where the implicit values are not given, leading to several unsupported problems in the validator.