### PR TITLE
fix(sat): derived clause were incorretly too strong in some corner cases

### DIFF
--- a/ci/scheduling.py
+++ b/ci/scheduling.py
@@ -12,10 +12,12 @@ solver = "target/ci/scheduler"
 solver_cmd = solver + " {kind} {instance} --expected-makespan {makespan}"
 
 instances = [
-    ("jobshop", "examples/scheduling/instances/jobshop/ft06.jsp", 55),
-    ("jobshop", "examples/scheduling/instances/jobshop/la01.jsp", 666),
-    ("openshop", "examples/scheduling/instances/openshop/taillard/tai04_04_01.osp", 193),
-]
+                ("jobshop", "examples/scheduling/instances/jobshop/ft06.jsp", 55),
+                ("jobshop", "examples/scheduling/instances/jobshop/la01.jsp", 666),
+                ("openshop", "examples/scheduling/instances/openshop/taillard/tai04_04_01.osp", 193),
+            ] + [
+                ("jobshop", "examples/scheduling/instances/jobshop/orb05.jsp", 887),
+            ] * 30
 
 for (kind, instance, makespan) in instances:
     cmd = solver_cmd.format(kind=kind, instance=instance, makespan=makespan).split(" ")
@@ -24,5 +26,3 @@ for (kind, instance, makespan) in instances:
     if solver_run.returncode != 0:
         print("Solver did not return expected result")
         exit(1)
-
-

--- a/solver/src/core/literals/lit_set.rs
+++ b/solver/src/core/literals/lit_set.rs
@@ -10,11 +10,6 @@ use std::fmt::{Debug, Formatter};
 ///  - `l` was previously inserted in the set; or
 ///  - another literal `l2` was previously inserted such that `l2.entails(l)`.
 ///
-/// # Limitations
-///
-/// The implementation is optimized for small, dynamic sets as it stores literals in an unsorted vector.
-/// A specialized implementation for large sets could be implemented with a `Map<VarBound, BoundValue>`
-///
 /// # Example
 /// ```
 /// use aries::core::literals::LitSet;
@@ -116,6 +111,12 @@ impl<T: IntoIterator<Item = Lit>> From<T> for LitSet {
             set.insert(l);
         }
         set
+    }
+}
+
+impl From<LitSet> for Vec<Lit> {
+    fn from(value: LitSet) -> Self {
+        value.literals().collect()
     }
 }
 

--- a/solver/src/core/literals/lit_set.rs
+++ b/solver/src/core/literals/lit_set.rs
@@ -10,6 +10,11 @@ use std::fmt::{Debug, Formatter};
 ///  - `l` was previously inserted in the set; or
 ///  - another literal `l2` was previously inserted such that `l2.entails(l)`.
 ///
+/// # Limitations
+///
+/// The implementation is optimized for small, dynamic sets as it stores literals in an unsorted vector.
+/// A specialized implementation for large sets could be implemented with a `Map<VarBound, BoundValue>`
+///
 /// # Example
 /// ```
 /// use aries::core::literals::LitSet;
@@ -111,12 +116,6 @@ impl<T: IntoIterator<Item = Lit>> From<T> for LitSet {
             set.insert(l);
         }
         set
-    }
-}
-
-impl From<LitSet> for Vec<Lit> {
-    fn from(value: LitSet) -> Self {
-        value.literals().collect()
     }
 }
 

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -446,7 +446,7 @@ impl Domains {
         // literals falsified at the current decision level, we need to proceed until there is a single one left (1UIP)
         self.queue.clear();
         // literals that are beyond the current decision level and will be part of the final clause
-        let mut result: LitSet = LitSet::with_capacity(128);
+        let mut result: Vec<Lit> = Vec::with_capacity(4);
 
         let decision_level = self.current_decision_level();
         let mut resolved = LitSet::new();
@@ -466,7 +466,7 @@ impl Domains {
                             }
                             DecisionLevelClass::Intermediate => {
                                 // implied before the current decision level, the negation of the literal will appear in the final clause (1UIP)
-                                result.insert(!l)
+                                result.push(!l)
                             }
                         }
                     }
@@ -474,7 +474,7 @@ impl Domains {
                     // the event is not entailed, must be part of an eager propagation
                     // Even if it was not necessary for this propagation to occur, it must be part of
                     // the clause for correctness
-                    result.insert(!l)
+                    result.push(!l)
                 }
             }
             debug_assert!(explanation.lits.is_empty());
@@ -487,7 +487,7 @@ impl Domains {
                 // if we were at the root decision level, we should have derived the empty clause
                 debug_assert!(decision_level != DecLvl::ROOT || result.is_empty());
                 return Conflict {
-                    clause: Disjunction::new(result.into()),
+                    clause: Disjunction::new(result),
                     resolved,
                 };
             }
@@ -526,9 +526,9 @@ impl Domains {
                 // the content of result is a conjunction of literal that imply `!l`
                 // build the conflict clause and exit
                 debug_assert!(self.queue.is_empty());
-                result.insert(!l.lit);
+                result.push(!l.lit);
                 return Conflict {
-                    clause: Disjunction::new(result.into()),
+                    clause: Disjunction::new(result),
                     resolved,
                 };
             }

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -1,6 +1,6 @@
 use crate::backtrack::{Backtrack, DecLvl, DecisionLevelClass, EventIndex, ObsTrail};
 use crate::collections::ref_store::RefMap;
-use crate::core::literals::{Disjunction, ImplicationGraph, LitSet};
+use crate::core::literals::{Disjunction, DisjunctionBuilder, ImplicationGraph, LitSet};
 use crate::core::state::cause::{DirectOrigin, Origin};
 use crate::core::state::event::Event;
 use crate::core::state::int_domains::IntDomains;
@@ -446,7 +446,7 @@ impl Domains {
         // literals falsified at the current decision level, we need to proceed until there is a single one left (1UIP)
         self.queue.clear();
         // literals that are beyond the current decision level and will be part of the final clause
-        let mut result: Vec<Lit> = Vec::with_capacity(4);
+        let mut result: DisjunctionBuilder = DisjunctionBuilder::with_capacity(32);
 
         let decision_level = self.current_decision_level();
         let mut resolved = LitSet::new();
@@ -487,7 +487,7 @@ impl Domains {
                 // if we were at the root decision level, we should have derived the empty clause
                 debug_assert!(decision_level != DecLvl::ROOT || result.is_empty());
                 return Conflict {
-                    clause: Disjunction::new(result),
+                    clause: result.into(),
                     resolved,
                 };
             }
@@ -528,7 +528,7 @@ impl Domains {
                 debug_assert!(self.queue.is_empty());
                 result.push(!l.lit);
                 return Conflict {
-                    clause: Disjunction::new(result),
+                    clause: result.into(),
                     resolved,
                 };
             }


### PR DESCRIPTION
Solves a bug in explanation that resulted in overly strong clauses.

fix: #135

