### PR TITLE
perf(collections): Introduce efficiently iterable versions of `RefMap` and `RefSet`

### DIFF
--- a/planning/planning/src/chronicles/analysis/fluent_hierarchy.rs
+++ b/planning/planning/src/chronicles/analysis/fluent_hierarchy.rs
@@ -1,6 +1,6 @@
 use crate::chronicles::analysis::TemplateID;
 use crate::chronicles::{EffectOp, Fluent, Problem};
-use aries::collections::ref_store::RefMap;
+use aries::collections::ref_store::IterableRefMap;
 use aries::model::symbols::SymId;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
@@ -9,11 +9,11 @@ use std::collections::{HashMap, HashSet};
 /// This one associates each action to an abstraction level which is returned as a map.
 /// THe level of the action is the one of the most abstract fluent the action contributes to (i.e. has an effect on).
 ///
-/// Note: 0 is the most abstract level.   
+/// Note: 0 is the most abstract level.
 pub fn hierarchy(pb: &Problem) -> HashMap<TemplateID, usize> {
     let resource_fluents = resource_fluents(pb);
 
-    let mut links: RefMap<SymId, HashSet<SymId>> = Default::default();
+    let mut links: IterableRefMap<SymId, HashSet<SymId>> = Default::default();
 
     let mut add_link = |src: SymId, tgt: SymId| {
         if resource_fluents.contains(&src) || resource_fluents.contains(&tgt) {
@@ -134,22 +134,22 @@ mod tarjan {
     can use `src/graph/graph_enumeration.rs` to convert their graph.
     */
 
-    use aries::collections::ref_store::RefMap;
+    use aries::collections::ref_store::IterableRefMap;
     use aries::model::symbols::SymId;
     use std::collections::HashSet;
 
     type V = SymId;
-    type Graph = RefMap<SymId, HashSet<SymId>>;
+    type Graph = IterableRefMap<SymId, HashSet<SymId>>;
 
     pub struct StronglyConnectedComponents {
         // The number of the SCC the vertex is in, starting from 1
-        pub component: RefMap<V, usize>,
+        pub component: IterableRefMap<V, usize>,
 
         // The discover time of the vertex with minimum discover time reachable
         // from this vertex. The MSB of the numbers are used to save whether the
         // vertex has been visited (but the MSBs are cleared after
         // the algorithm is done)
-        pub state: RefMap<V, u64>,
+        pub state: IterableRefMap<V, u64>,
 
         // The total number of SCCs
         pub num_components: usize,
@@ -186,8 +186,8 @@ mod tarjan {
     impl StronglyConnectedComponents {
         pub fn new(graph: &Graph) -> Self {
             let mut scc = StronglyConnectedComponents {
-                component: RefMap::default(),
-                state: RefMap::default(),
+                component: Default::default(),
+                state: Default::default(),
                 num_components: 0,
                 stack: vec![],
                 current_time: 1,

--- a/solver/src/collections/heap.rs
+++ b/solver/src/collections/heap.rs
@@ -73,7 +73,8 @@ impl<K: Ref, P: PartialOrd + Copy> IdxHeap<K, P> {
         for &k in &self.keys {
             self.index.remove(k)
         }
-        debug_assert!(self.index.is_empty());
+        // deactivated check as potentially costly
+        // debug_assert!(self.index.is_empty());
         self.keys.clear();
     }
 
@@ -178,6 +179,7 @@ impl<K: Ref, P: PartialOrd + Copy> IdxHeap<K, P> {
     /// For this to be correct, it should not impact the relative ordering of two items in the
     /// heap.
     pub fn change_all_priorities_in_place<F: Fn(&mut P)>(&mut self, f: F) {
+        #[allow(deprecated)] // typically not a hot method (in the use context)
         for entry in self.index.values_mut() {
             match entry {
                 In(loc) => f(&mut self.heap[*loc].prio),

--- a/solver/src/collections/ref_store.rs
+++ b/solver/src/collections/ref_store.rs
@@ -406,19 +406,23 @@ impl<K: Ref, V> RefMap<K, V> {
     }
 
     /// Removes all elements from the Map.
-    #[inline(never)]
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn clear(&mut self) {
         for x in &mut self.entries {
             *x = None
         }
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn len(&self) -> usize {
+        #[allow(deprecated)]
         self.entries().count()
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        #[allow(deprecated)]
+        (self.len() == 0)
     }
 
     pub fn remove(&mut self, k: K) {
@@ -464,18 +468,22 @@ impl<K: Ref, V> RefMap<K, V> {
         &mut self[k]
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn keys(&self) -> impl Iterator<Item = K> + '_ {
         (0..self.entries.len()).map(K::from).filter(move |k| self.contains(*k))
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn values(&self) -> impl Iterator<Item = &V> {
         self.entries.iter().filter_map(|x| x.as_ref())
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> {
         self.entries.iter_mut().filter_map(|x| x.as_mut())
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn entries(&self) -> impl Iterator<Item = (K, &V)> {
         self.entries
             .iter()
@@ -483,6 +491,7 @@ impl<K: Ref, V> RefMap<K, V> {
             .filter_map(|(idx, value)| value.as_ref().map(|v| (K::from(idx), v)))
     }
 
+    #[deprecated(note = "Performance hazard. Use an IterableRefMap instead.")]
     pub fn entries_mut(&mut self) -> impl Iterator<Item = (K, &mut V)> {
         self.entries
             .iter_mut()
@@ -518,6 +527,7 @@ impl<K: Ref, V> FromIterator<(K, V)> for RefMap<K, V> {
 impl<K: Ref + Debug, V: Debug> std::fmt::Debug for RefMap<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "[")?;
+        #[allow(deprecated)] // debug is not performance sensitive
         for (k, v) in self.entries() {
             write!(f, "{k:?} -> {v:?}, ")?;
         }

--- a/solver/src/collections/set.rs
+++ b/solver/src/collections/set.rs
@@ -1,5 +1,7 @@
 use crate::collections::ref_store::{Ref, RefMap};
 
+use super::ref_store::IterableRefMap;
+
 /// A set of values that can be converted into small unsigned integers.
 #[derive(Clone)]
 pub struct RefSet<K> {
@@ -46,6 +48,56 @@ impl<K: Ref> RefSet<K> {
 }
 
 impl<K: Ref> Default for RefSet<K> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A set of values that can be converted into small unsigned integers.
+/// This extends `RefSet` with a vector of all elements of the set, allowing for fast iteration
+/// and clearing.
+/// THe down side would be slightly slower insertion, where the set msut be queried for duplicated entries.
+#[derive(Clone)]
+pub struct IterableRefSet<K> {
+    set: IterableRefMap<K, ()>,
+}
+
+impl<K: Ref> IterableRefSet<K> {
+    pub fn new() -> IterableRefSet<K> {
+        IterableRefSet {
+            set: Default::default(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    pub fn insert(&mut self, k: K) {
+        self.set.insert(k, ());
+    }
+
+    pub fn clear(&mut self) {
+        self.set.clear()
+    }
+
+    pub fn contains(&self, k: K) -> bool {
+        self.set.contains(k)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = K> + '_
+    where
+        K: From<usize>,
+    {
+        self.set.entries().map(|(k, _)| k)
+    }
+}
+
+impl<K: Ref> Default for IterableRefSet<K> {
     fn default() -> Self {
         Self::new()
     }

--- a/solver/src/collections/set.rs
+++ b/solver/src/collections/set.rs
@@ -17,11 +17,13 @@ impl<K: Ref> RefSet<K> {
 
     #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn len(&self) -> usize {
+        #[allow(deprecated)]
         self.set.len()
     }
 
     #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn is_empty(&self) -> bool {
+        #[allow(deprecated)]
         self.set.is_empty()
     }
 
@@ -35,6 +37,7 @@ impl<K: Ref> RefSet<K> {
 
     #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn clear(&mut self) {
+        #[allow(deprecated)]
         self.set.clear()
     }
 
@@ -47,6 +50,7 @@ impl<K: Ref> RefSet<K> {
     where
         K: From<usize>,
     {
+        #[allow(deprecated)]
         self.set.entries().map(|(k, _)| k)
     }
 }

--- a/solver/src/collections/set.rs
+++ b/solver/src/collections/set.rs
@@ -15,10 +15,12 @@ impl<K: Ref> RefSet<K> {
         }
     }
 
+    #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn len(&self) -> usize {
         self.set.len()
     }
 
+    #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn is_empty(&self) -> bool {
         self.set.is_empty()
     }
@@ -31,6 +33,7 @@ impl<K: Ref> RefSet<K> {
         self.set.remove(k);
     }
 
+    #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn clear(&mut self) {
         self.set.clear()
     }
@@ -39,6 +42,7 @@ impl<K: Ref> RefSet<K> {
         self.set.contains(k)
     }
 
+    #[deprecated(note = "Performance hazard. Use an iterableRefSet instead.")]
     pub fn iter(&self) -> impl Iterator<Item = K> + '_
     where
         K: From<usize>,

--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -21,6 +21,7 @@ use crate::reasoners::cp::max::AtLeastOneGeq;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
 use anyhow::Context;
 use mul::VarEqVarMulLit;
+use set::IterableRefSet;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
@@ -121,7 +122,7 @@ pub struct Cp {
     pending_propagators: Vec<PropagatorId>,
     /// Datastructure used in `propagate` to keep track of which propagators should be triggered.
     /// Not stateful. Present here only to avoid reallocations
-    pending_propagations: RefSet<PropagatorId>,
+    pending_propagations: IterableRefSet<PropagatorId>,
     pub stats: Stats,
 }
 

--- a/solver/src/reasoners/sat/clauses/mod.rs
+++ b/solver/src/reasoners/sat/clauses/mod.rs
@@ -409,6 +409,7 @@ impl ClauseDb {
     }
 
     pub fn all_clauses(&self) -> impl Iterator<Item = ClauseId> + '_ {
+        #[allow(deprecated)] // ok because we know the table to be dense
         self.metadata.keys()
     }
 
@@ -457,6 +458,7 @@ impl ClauseDb {
     }
 
     fn rescale_activities(&mut self) {
+        #[allow(deprecated)] // of because we know the table to be dense
         for meta in self.metadata.values_mut() {
             meta.activity *= 1e-100_f64
         }
@@ -468,6 +470,7 @@ impl ClauseDb {
     ///  - are not locked, and
     ///  - have a high LBD value
     pub fn reduce_db<F: Fn(ClauseId) -> bool>(&mut self, locked: F, remove_watch: &mut impl FnMut(ClauseId, Lit)) {
+        #[allow(deprecated)] // ok because we know the table to be dense
         let mut clauses: Vec<_> = self
             .metadata
             .entries()

--- a/solver/src/reasoners/sat/sat_solver.rs
+++ b/solver/src/reasoners/sat/sat_solver.rs
@@ -1,5 +1,5 @@
 use crate::backtrack::{Backtrack, DecLvl, ObsTrailCursor, Trail};
-use crate::collections::set::RefSet;
+use crate::collections::set::{IterableRefSet, RefSet};
 use crate::core::literals::{Disjunction, WatchSet, Watches};
 use crate::core::state::{Domains, DomainsSnapshot, Event, Explanation, InferenceCause};
 use crate::core::*;
@@ -133,7 +133,7 @@ pub struct SatSolver {
     /// A working data structure to avoid allocations during propagation
     working_watches: WatchSet<ClauseId>,
     /// A local datastructure used to compute LBD (only present here to avoid allocations)
-    working_lbd_compute: RefSet<DecLvl>,
+    working_lbd_compute: IterableRefSet<DecLvl>,
 }
 impl SatSolver {
     pub fn new(identity: ReasonerId) -> SatSolver {

--- a/solver/src/reasoners/stn/theory/bound_propagation.rs
+++ b/solver/src/reasoners/stn/theory/bound_propagation.rs
@@ -1,7 +1,10 @@
 use std::{cell::RefCell, cmp::Reverse};
 
 use crate::{
-    collections::{heap::IdxHeap, ref_store::RefMap},
+    collections::{
+        heap::IdxHeap,
+        ref_store::{IterableRefMap, RefMap},
+    },
     reasoners::stn::theory::{Identity, ModelUpdateCause},
 };
 
@@ -64,8 +67,8 @@ impl Dij {
             self.potential.remove(v);
             self.init.remove(v);
         }
-        debug_assert!(self.potential.is_empty());
-        debug_assert!(self.init.is_empty());
+        // check deactivated because potentially costly for these datastructures
+        // debug_assert!(self.potential.is_empty() && self.init.is_empty());
         self.modified_vars.clear();
         self.heap.clear();
     }
@@ -250,16 +253,13 @@ impl Dij {
 #[derive(Default, Clone)]
 struct MinHeap {
     heap: IdxHeap<SignedVar, Reverse<IntCst>>,
-    pred: RefMap<SignedVar, PropagatorId>,
+    pred: IterableRefMap<SignedVar, PropagatorId>,
 }
 
 impl MinHeap {
     pub fn clear(&mut self) {
-        for k in self.heap.keys() {
-            self.pred.remove(k);
-        }
-        debug_assert!(self.pred.is_empty());
         self.heap.clear();
+        self.pred.clear();
     }
     pub fn insert_init(&mut self, v: SignedVar, cost: IntCst) {
         self.heap.declare_element(v, Reverse(cost));

--- a/solver/src/reasoners/stn/theory/distances.rs
+++ b/solver/src/reasoners/stn/theory/distances.rs
@@ -406,7 +406,10 @@ impl<V: Ref> PotentialUpdate<V> {
     }
 
     pub fn get_prefix(&self, v: V) -> Option<IntCst> {
-        debug_assert_eq!(self.prefixes.len(), self.prefix_lookup.len(), "dirty state");
+        #[allow(deprecated)]
+        {
+            debug_assert_eq!(self.prefixes.len(), self.prefix_lookup.len(), "dirty state");
+        }
         self.prefix_lookup.get(v).copied()
     }
 

--- a/solver/src/solver/search/conflicts.rs
+++ b/solver/src/solver/search/conflicts.rs
@@ -9,7 +9,7 @@ use crate::model::Model;
 use crate::solver::search::{Decision, SearchControl};
 use crate::solver::stats::Stats;
 
-use crate::collections::set::RefSet;
+use crate::collections::set::IterableRefSet;
 use itertools::Itertools;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -197,7 +197,7 @@ impl Default for Params {
         Params {
             // Reasoned is normally the most efficient but our implementation for explanation is
             // not always supporting it.
-            active: ActiveLiterals::Resolved,
+            active: ActiveLiterals::Reasoned,
             heuristic: Heuristic::LearningRate,
             value_selection: ValueSelection {
                 solution_guidance: true,
@@ -741,7 +741,7 @@ impl<Var> SearchControl<Var> for ConflictBasedBrancher {
 }
 
 fn lbd(clause: &Conflict, model: &Domains) -> u32 {
-    let mut working_lbd_compute = RefSet::new();
+    let mut working_lbd_compute = IterableRefSet::new();
 
     let mut uncounted = 0u32;
 

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -1,5 +1,5 @@
 use crate::backtrack::{Backtrack, DecLvl};
-use crate::collections::set::RefSet;
+use crate::collections::set::IterableRefSet;
 use crate::core::literals::Disjunction;
 use crate::core::state::*;
 use crate::core::*;
@@ -806,7 +806,7 @@ impl<Lbl: Label> Solver<Lbl> {
     }
 
     fn lbd(&self, clause: &Conflict, model: &Domains) -> u32 {
-        let mut working_lbd_compute = RefSet::new();
+        let mut working_lbd_compute = IterableRefSet::new();
 
         for &l in clause.literals() {
             if !model.entails(!l) {
@@ -830,7 +830,7 @@ impl<Lbl: Label> Solver<Lbl> {
     /// Returns:
     /// - `Ok(())`: if quiescence was reached without finding any conflict
     /// - `Err(clause)`: if a conflict was found. In this case, `clause` is a conflicting cause in the current
-    ///   decision level that   
+    ///   decision level that
     #[instrument(level = "trace", skip(self))]
     pub fn propagate(&mut self) -> Result<(), Conflict> {
         match self.post_constraints() {


### PR DESCRIPTION
- feat(collections): Add a variant of RefSet/RefMap that supports O(n) iteration and clearing
- perf(cp): use optimized data structure for accumulating propagators to trigger
- chore: deprecate iterator-based method on RefSet and upgrade their users to IterableRefSet
- chore: deprecate iteration-based methods on RefMap and update their usage
