### PR TITLE
perf(stn): Allow having edges with dynamic upper bound in the STN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "bit-set",
  "crossbeam-channel",
  "env_param",
+ "hashbrown 0.15.2",
  "itertools 0.13.0",
  "lazy_static",
  "lru",
@@ -624,6 +625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +719,17 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2021"
 cpu_cycles = []
 
 
-
-
 [dependencies]
 anyhow = { workspace = true }
 streaming-iterator = "0.1.5"
@@ -31,6 +29,7 @@ tracing = { workspace = true }
 lru = "0.12.3"
 rand = { workspace = true }
 num-rational = { workspace = true }
+hashbrown = "0.15"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
This allows having redundant propagator for a common pattern of linear constraints (encoding variable durations between two timepoints).

In some (not so infrequent) cases, it allows detecting early an inconsistency that was previously only detected after a very long propagation loop between the STN and linear constraint propagator, iteratively decreasing the UB of a variable until its LB.
Now this would be trivially detected as a cycle in the STN.