### PR TITLE
Assumption solving

### DIFF
--- a/examples/smt/tests/smt.rs
+++ b/examples/smt/tests/smt.rs
@@ -1,4 +1,4 @@
-use aries::backtrack::{Backtrack, DecLvl};
+use aries::backtrack::Backtrack;
 use aries::core::state::OptDomain;
 use aries::core::Lit;
 use aries::model::extensions::AssignmentExt;
@@ -62,6 +62,7 @@ fn minimize() {
 
     let mut solver = Solver::new(model);
     assert!(solver.solve().unwrap().is_some());
+    solver.reset();
     match solver.minimize(c).unwrap() {
         None => panic!(),
         Some((val, _)) => assert_eq!(val, 7),
@@ -80,6 +81,7 @@ fn minimize_small() {
 
     let mut solver = Solver::new(model);
     assert!(solver.solve().unwrap().is_some());
+    solver.reset();
     match solver.minimize(a).unwrap() {
         None => panic!(),
         Some((val, _)) => assert_eq!(val, 6),
@@ -120,7 +122,7 @@ fn int_bounds() {
 
     let mut solver = Solver::new(model);
     solver.enforce_all(constraints, []);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     let check_dom = |v, lb, ub| {
         assert_eq!(solver.model.domain_of(v), (lb, ub));
     };
@@ -148,7 +150,7 @@ fn bools_as_ints() {
 
     let mut solver = Solver::new(model);
 
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.boolean_value_of(a), None);
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
@@ -183,25 +185,25 @@ fn ints_and_bools() {
 
     let mut solver = Solver::new(model);
 
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 10));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(leq(i, ia), []);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 1));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(gt(ia, i), []);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 0));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(geq(i, 0), []);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.domain_of(i), (0, 0));
     assert_eq!(solver.model.domain_of(ia), (1, 1));
     assert_eq!(solver.model.boolean_value_of(a), Some(true));
@@ -237,7 +239,7 @@ fn optional_hierarchy() {
 
     // solver.model.print_state();
 
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
 
     // solver.model.print_state();
 
@@ -247,7 +249,7 @@ fn optional_hierarchy() {
     assert_eq!(solver.model.opt_domain_of(vars[2]), Unknown(5, 10));
 
     solver.decide(Lit::leq(i, 9));
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
 
     assert_eq!(solver.model.opt_domain_of(i), Unknown(-10, 9));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Unknown(0, 8));
@@ -258,7 +260,7 @@ fn optional_hierarchy() {
     // solver.model.state.print();
 
     solver.decide(Lit::leq(i, 4));
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
 
     // println!();
     // solver.model.state.print();
@@ -271,7 +273,7 @@ fn optional_hierarchy() {
 
     solver.save_state();
     solver.decide(p);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, 4));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Unknown(0, 4));
     assert_eq!(solver.model.opt_domain_of(vars[1]), Unknown(-10, -5));
@@ -280,21 +282,21 @@ fn optional_hierarchy() {
     println!("======================");
 
     solver.decide(Lit::leq(i, -1));
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, -1));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Absent);
     assert_eq!(solver.model.opt_domain_of(vars[1]), Unknown(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[2]), Absent);
 
     solver.decide(scopes[1]);
-    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
+    assert!(solver.propagate_and_backtrack_to_consistent().is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Absent);
     assert_eq!(solver.model.opt_domain_of(vars[1]), Present(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[2]), Absent);
 
     // solver.decide(!p);
-    // assert!(matches!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok(), Ok(true));
+    // assert!(matches!(solver.propagate_and_backtrack_to_consistent().is_ok(), Ok(true));
     // solver.model.discrete.print();
 
     // assert_eq!(solver.model.opt_domain_of(i), Absent);

--- a/examples/smt/tests/smt.rs
+++ b/examples/smt/tests/smt.rs
@@ -1,4 +1,4 @@
-use aries::backtrack::Backtrack;
+use aries::backtrack::{Backtrack, DecLvl};
 use aries::core::state::OptDomain;
 use aries::core::Lit;
 use aries::model::extensions::AssignmentExt;
@@ -120,7 +120,7 @@ fn int_bounds() {
 
     let mut solver = Solver::new(model);
     solver.enforce_all(constraints, []);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     let check_dom = |v, lb, ub| {
         assert_eq!(solver.model.domain_of(v), (lb, ub));
     };
@@ -148,7 +148,7 @@ fn bools_as_ints() {
 
     let mut solver = Solver::new(model);
 
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.boolean_value_of(a), None);
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
@@ -183,25 +183,25 @@ fn ints_and_bools() {
 
     let mut solver = Solver::new(model);
 
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 10));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(leq(i, ia), []);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 1));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(gt(ia, i), []);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.domain_of(i), (-10, 0));
     assert_eq!(solver.model.domain_of(ia), (0, 1));
     assert_eq!(solver.model.boolean_value_of(a), None);
 
     solver.enforce(geq(i, 0), []);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.domain_of(i), (0, 0));
     assert_eq!(solver.model.domain_of(ia), (1, 1));
     assert_eq!(solver.model.boolean_value_of(a), Some(true));
@@ -237,7 +237,7 @@ fn optional_hierarchy() {
 
     // solver.model.print_state();
 
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
 
     // solver.model.print_state();
 
@@ -247,7 +247,7 @@ fn optional_hierarchy() {
     assert_eq!(solver.model.opt_domain_of(vars[2]), Unknown(5, 10));
 
     solver.decide(Lit::leq(i, 9));
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
 
     assert_eq!(solver.model.opt_domain_of(i), Unknown(-10, 9));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Unknown(0, 8));
@@ -258,7 +258,7 @@ fn optional_hierarchy() {
     // solver.model.state.print();
 
     solver.decide(Lit::leq(i, 4));
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
 
     // println!();
     // solver.model.state.print();
@@ -271,7 +271,7 @@ fn optional_hierarchy() {
 
     solver.save_state();
     solver.decide(p);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, 4));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Unknown(0, 4));
     assert_eq!(solver.model.opt_domain_of(vars[1]), Unknown(-10, -5));
@@ -280,21 +280,21 @@ fn optional_hierarchy() {
     println!("======================");
 
     solver.decide(Lit::leq(i, -1));
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, -1));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Absent);
     assert_eq!(solver.model.opt_domain_of(vars[1]), Unknown(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[2]), Absent);
 
     solver.decide(scopes[1]);
-    assert!(solver.propagate_and_backtrack_to_consistent());
+    assert!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok());
     assert_eq!(solver.model.opt_domain_of(i), Present(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[0]), Absent);
     assert_eq!(solver.model.opt_domain_of(vars[1]), Present(-10, -5));
     assert_eq!(solver.model.opt_domain_of(vars[2]), Absent);
 
     // solver.decide(!p);
-    // assert!(matches!(solver.propagate_and_backtrack_to_consistent(), Ok(true));
+    // assert!(matches!(solver.propagate_and_backtrack_to_consistent(DecLvl::ROOT).is_ok(), Ok(true));
     // solver.model.discrete.print();
 
     // assert_eq!(solver.model.opt_domain_of(i), Absent);

--- a/planning/planners/src/encode.rs
+++ b/planning/planners/src/encode.rs
@@ -381,7 +381,7 @@ fn enforce_refinement(t: TaskRef, supporters: Vec<TaskRef>, model: &mut Model) {
 /// Multiply an integer atom with a literal.
 /// The result is a linear sum evaluated to the atom if the literal is true, and to 0 otherwise.
 fn iatom_mul_lit(model: &mut Model, atom: IAtom, lit: Lit) -> LinearSum {
-    debug_assert!(model.state.implies(lit, model.presence_literal(atom.var.into())));
+    debug_assert!(model.state.implies(lit, model.presence_literal(atom.var)));
     if atom.var == IVar::ZERO {
         // Constant variable
         if atom.shift == 0 {
@@ -892,7 +892,7 @@ pub fn encode(pb: &FiniteProblem, metric: Option<Metric>) -> std::result::Result
                     }
                     // each term of the increase value is present
                     for term in inc_val.terms() {
-                        let p = solver.model.presence_literal(term.var().into());
+                        let p = solver.model.presence_literal(term.var());
                         active_inc_conjunction.push(p);
                     }
                     // compute wether the increase is active in the condition value
@@ -903,7 +903,7 @@ pub fn encode(pb: &FiniteProblem, metric: Option<Metric>) -> std::result::Result
                     inc_support.entry(inc_id).or_default().push(active_inc);
                     for term in inc_val.terms() {
                         // compute some static implication for better propagation
-                        let p = solver.model.presence_literal(term.var().into());
+                        let p = solver.model.presence_literal(term.var());
                         if !solver.model.entails(p) {
                             solver.model.state.add_implication(active_inc, p);
                         }
@@ -914,7 +914,7 @@ pub fn encode(pb: &FiniteProblem, metric: Option<Metric>) -> std::result::Result
                 // enforce the condition value to be the sum of the assignment values and the increase values
                 for term in cond_val_sum.terms() {
                     // compute some static implication for better propagation
-                    let p = solver.model.presence_literal(term.var().into());
+                    let p = solver.model.presence_literal(term.var());
                     if !solver.model.entails(p) {
                         solver.model.state.add_implication(supported_by, p);
                     }

--- a/solver/src/core/state/cause.rs
+++ b/solver/src/core/state/cause.rs
@@ -8,6 +8,8 @@ use crate::reasoners::ReasonerId;
 pub enum Cause {
     /// Event caused by a decision.
     Decision,
+    /// Event caused by an assumption.
+    Assumption,
     /// Event that resulted from the encoding of a constraint.
     /// This should only occur at the root decision level.
     Encoding,
@@ -32,6 +34,7 @@ impl From<Cause> for DirectOrigin {
     fn from(c: Cause) -> Self {
         match c {
             Cause::Decision => DirectOrigin::Decision,
+            Cause::Assumption => DirectOrigin::Assumption,
             Cause::Encoding => DirectOrigin::Encoding,
             Cause::Inference(i) => DirectOrigin::ExternalInference(i),
         }
@@ -42,6 +45,7 @@ impl From<Cause> for Origin {
     fn from(c: Cause) -> Self {
         match c {
             Cause::Decision => Origin::Direct(DirectOrigin::Decision),
+            Cause::Assumption => Origin::Direct(DirectOrigin::Assumption),
             Cause::Encoding => Origin::Direct(DirectOrigin::Encoding),
             Cause::Inference(i) => Origin::Direct(DirectOrigin::ExternalInference(i)),
         }
@@ -75,6 +79,7 @@ pub enum Origin {
 }
 impl Origin {
     pub const DECISION: Origin = Origin::Direct(DirectOrigin::Decision);
+    pub const ASSUMPTION: Origin = Origin::Direct(DirectOrigin::Assumption);
 
     pub const fn implication_propagation(lit: Lit) -> Origin {
         Origin::Direct(DirectOrigin::ImplicationPropagation(lit))
@@ -91,6 +96,7 @@ impl Origin {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DirectOrigin {
     Decision,
+    Assumption,
     /// Result of encoding a constraint at the root decision level.
     Encoding,
     /// The event is due to an inference.

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -413,7 +413,7 @@ impl Domains {
     ///
     /// The update of `l` must not directly originate from a decision as it is necessarily the case that
     /// `!l` holds in the current state. It is thus considered a logic error to impose an obviously wrong decision.
-    /// 
+    ///
     /// It can, however, directly originate from an assumption (in which case we are necessarily UNSAT, by the way).
     pub fn clause_for_invalid_update(&mut self, failed: InvalidUpdate, explainer: &mut impl Explainer) -> Conflict {
         let InvalidUpdate(literal, cause) = failed;
@@ -538,11 +538,10 @@ impl Domains {
     }
 
     pub fn extract_unsat_core(&mut self, conflict: &Conflict, explainer: &mut impl Explainer) -> Explanation {
-
         let mut explanation = Explanation::new();
-        let mut result = Explanation::new();    // FIXME: use a (conjunctive) litset to avoid duplicates ? tests seem to show no difference...
+        let mut result = Explanation::new(); // FIXME: use a (conjunctive) litset to avoid duplicates ? tests seem to show no difference...
 
-        for &lit in conflict.clause.literals() { // explanation.push(!lit);
+        for &lit in conflict.clause.literals() {
             if self.entails(!lit) {
                 explanation.push(!lit);
             } else {
@@ -578,9 +577,9 @@ impl Domains {
             let (lit, _) = self.queue.pop().unwrap();
 
             if let Some(implying_lits) = self.implying_literals(lit, explainer) {
-                for l in implying_lits { explanation.push(l); }
+                explanation.lits.extend(implying_lits);
             }
-        };
+        }
         result
     }
 
@@ -1135,7 +1134,7 @@ mod tests {
 
         let conflict = model.clause_for_invalid_update(err, &mut network);
         let unsat_core = model.extract_unsat_core(&conflict, &mut network).lits;
-        let unsat_core_set: HashSet::<Lit> = unsat_core.iter().copied().collect();
+        let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
 
         let mut expected = HashSet::new();
         expected.insert(a);
@@ -1154,7 +1153,7 @@ mod tests {
 
         let conflict = model.clause_for_invalid_update(err, &mut network);
         let unsat_core = model.extract_unsat_core(&conflict, &mut network).lits;
-        let unsat_core_set: HashSet::<Lit> = unsat_core.iter().copied().collect();
+        let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
 
         let mut expected = HashSet::new();
         expected.insert(a);
@@ -1169,13 +1168,12 @@ mod tests {
 
         let conflict = model.clause_for_invalid_update(err, &mut network);
         let unsat_core = model.extract_unsat_core(&conflict, &mut network).lits;
-        let unsat_core_set: HashSet::<Lit> = unsat_core.iter().copied().collect();
+        let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
 
         let mut expected = HashSet::new();
         expected.insert(a);
         expected.insert(b);
         expected.insert(h);
         assert_eq!(unsat_core_set, expected);
-
     }
 }

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -568,7 +568,7 @@ impl Domains {
         // we should be in a state where the literal is not true yet, but immediately implied
         debug_assert!(!state.entails(literal));
         match cause {
-            Origin::Direct(DirectOrigin::Decision | DirectOrigin::Encoding) => panic!(),
+            Origin::Direct(DirectOrigin::Decision | DirectOrigin::Assumption | DirectOrigin::Encoding) => panic!(),
             Origin::Direct(DirectOrigin::ExternalInference(cause)) => {
                 // ask for a clause (l1 & l2 & ... & ln) => lit
                 explainer.explain(cause, literal, state, explanation);
@@ -579,7 +579,7 @@ impl Domains {
                 debug_assert!(state.entails(!invalid_lit));
                 explanation.push(!invalid_lit);
                 match cause {
-                    DirectOrigin::Decision | DirectOrigin::Encoding => {
+                    DirectOrigin::Decision | DirectOrigin::Assumption | DirectOrigin::Encoding => {
                         explanation.push(invalid_lit);
                     }
                     DirectOrigin::ExternalInference(cause) => {
@@ -615,7 +615,7 @@ impl Domains {
 
         if matches!(
             event.cause,
-            Origin::Direct(DirectOrigin::Decision | DirectOrigin::Encoding)
+            Origin::Direct(DirectOrigin::Decision | DirectOrigin::Assumption | DirectOrigin::Encoding)
         ) {
             None
         } else {

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -1252,7 +1252,7 @@ mod tests {
 
         let unsat_core = model.extract_unsat_core_after_invalid_update(err, &mut network).lits;
         let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
-        
+
         let mut expected = HashSet::new();
         expected.insert(x.leq(3)); // Previously, an unfixed bug would result in [x <= 5] instead of the "actual" assumption [x <= 3]
         expected.insert(y.leq(4));

--- a/solver/src/core/state/domains.rs
+++ b/solver/src/core/state/domains.rs
@@ -1063,8 +1063,8 @@ mod tests {
         let g = Lit::geq(model.new_var(0, 1), 1);
         let h = Lit::geq(model.new_var(0, 1), 1);
 
-        // assumptions: a, b, d
-        // expected core: a, b
+        // assumptions: a, b, d, g
+        // expected core: a, b, g
 
         // constraint 0: "a => c"
         // constraint 1: "b & c => f"
@@ -1173,25 +1173,6 @@ mod tests {
         assert_eq!(model.bounds(e.variable()), (1, 1));
 
         model.save_state();
-        model.decide(g).unwrap();
-        assert_eq!(model.bounds(g.variable()), (1, 1));
-        let err = match propagate(&mut model) {
-            Err(err) => err,
-            _ => panic!(),
-        };
-
-        let conflict = model.clause_for_invalid_inferrence(err, &mut network);
-        let unsat_core = model.extract_unsat_core_after_conflict(conflict, &mut network).lits;
-        let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
-
-        let mut expected = HashSet::new();
-        expected.insert(a);
-        expected.insert(b);
-        assert_eq!(unsat_core_set, expected);
-
-        model.restore_last();
-
-        model.save_state();
         model.assume(g).unwrap();
         assert_eq!(model.bounds(g.variable()), (1, 1));
         let err = match propagate(&mut model) {
@@ -1208,22 +1189,6 @@ mod tests {
         expected.insert(a);
         expected.insert(b);
         expected.insert(g);
-        assert_eq!(unsat_core_set, expected);
-
-        model.restore_last();
-
-        model.save_state();
-        let err = model.assume(h).unwrap_err();
-
-        let unsat_core = model
-            .extract_unsat_core_after_invalid_assumption(err, &mut network)
-            .lits;
-        let unsat_core_set: HashSet<Lit> = unsat_core.iter().copied().collect();
-
-        let mut expected = HashSet::new();
-        expected.insert(a);
-        expected.insert(b);
-        expected.insert(h);
         assert_eq!(unsat_core_set, expected);
     }
 

--- a/solver/src/core/state/domains/minimize.rs
+++ b/solver/src/core/state/domains/minimize.rs
@@ -180,8 +180,8 @@ impl State {
                                 unreachable!()
                             };
                             let event = doms.get_event(event);
-                            if event.cause == Origin::DECISION {
-                                // decision => not redundant
+                            if matches!(event.cause, Origin::DECISION | Origin::ASSUMPTION) {
+                                // decision or assumption => not redundant
                                 self.mark_not_redundant(cur);
                                 Some(false)
                             } else {

--- a/solver/src/core/state/explanation.rs
+++ b/solver/src/core/state/explanation.rs
@@ -6,7 +6,7 @@ use std::collections::BinaryHeap;
 /// Builder for a conjunction of literals that make the explained literal true
 #[derive(Clone, Debug)]
 pub struct Explanation {
-    pub lits: Vec<Lit>,
+    pub(crate) lits: Vec<Lit>,
 }
 impl Explanation {
     pub fn new() -> Self {
@@ -23,6 +23,11 @@ impl Explanation {
     pub fn push(&mut self, lit: Lit) {
         self.lits.push(lit)
     }
+
+    pub fn extend(&mut self, additional_lits: impl IntoIterator<Item = Lit>) {
+        self.lits.extend(additional_lits);
+    }
+
     pub fn pop(&mut self) -> Option<Lit> {
         self.lits.pop()
     }
@@ -38,6 +43,12 @@ impl Explanation {
 impl Default for Explanation {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl From<Vec<Lit>> for Explanation {
+    fn from(lits: Vec<Lit>) -> Self {
+        Explanation { lits }
     }
 }
 

--- a/solver/src/model/extensions/assignments.rs
+++ b/solver/src/model/extensions/assignments.rs
@@ -6,6 +6,7 @@ use crate::model::lang::{Atom, Cst, IAtom, IVar, SAtom};
 use crate::model::symbols::SymId;
 use crate::model::symbols::{ContiguousSymbols, TypedSym};
 use num_rational::Rational32;
+use state::Term;
 
 /// Extension methods for an object containing a partial or total assignment to a problem.
 pub trait AssignmentExt {
@@ -13,7 +14,7 @@ pub trait AssignmentExt {
 
     fn var_domain(&self, var: impl Into<IAtom>) -> IntDomain;
 
-    fn presence_literal(&self, variable: VarRef) -> Lit;
+    fn presence_literal(&self, variable: impl Term) -> Lit;
 
     fn value_of_literal(&self, literal: Lit) -> Option<bool> {
         if self.entails(literal) {
@@ -37,7 +38,7 @@ pub trait AssignmentExt {
     fn sym_present(&self, atom: impl Into<SAtom>) -> Option<bool> {
         let atom = atom.into();
         match atom {
-            SAtom::Var(v) => self.boolean_value_of(self.presence_literal(v.into())),
+            SAtom::Var(v) => self.boolean_value_of(self.presence_literal(v)),
             SAtom::Cst(_) => Some(true),
         }
     }
@@ -66,7 +67,7 @@ pub trait AssignmentExt {
     fn opt_domain_of(&self, atom: impl Into<IAtom>) -> OptDomain {
         let atom = atom.into();
         let (lb, ub) = self.domain_of(atom);
-        let prez = self.presence_literal(atom.var.into());
+        let prez = self.presence_literal(atom.var);
         match self.value_of_literal(prez) {
             Some(true) => OptDomain::Present(lb, ub),
             Some(false) => OptDomain::Absent,

--- a/solver/src/model/extensions/mod.rs
+++ b/solver/src/model/extensions/mod.rs
@@ -13,6 +13,7 @@ pub mod partial_assignment;
 pub use assignments::*;
 pub use disjunction::*;
 pub use format::*;
+use state::Term;
 
 use crate::core::state::{Domains, IntDomain};
 use crate::core::*;
@@ -59,7 +60,7 @@ impl AssignmentExt for SavedAssignment {
         }
     }
 
-    fn presence_literal(&self, variable: VarRef) -> Lit {
+    fn presence_literal(&self, variable: impl Term) -> Lit {
         self.presence(variable)
     }
 

--- a/solver/src/model/model_impl.rs
+++ b/solver/src/model/model_impl.rs
@@ -591,7 +591,7 @@ impl<Lbl> AssignmentExt for Model<Lbl> {
         self.state.var_domain(var)
     }
 
-    fn presence_literal(&self, variable: VarRef) -> Lit {
+    fn presence_literal(&self, variable: impl Term) -> Lit {
         self.state.presence(variable)
     }
 

--- a/solver/src/reasoners/eq/dense.rs
+++ b/solver/src/reasoners/eq/dense.rs
@@ -635,10 +635,10 @@ impl DenseEqTheory {
     /// DomNeq: (x != v) & (x <= v) => (x <= v - 1)
     ///         (x != v) & (x >= v) => (x >= v + 1)
     ///         (x != v) & (-x <= -v) => (-x <= -v-1)  (rewrite of previous for uniformity with signed vars
-    ///           
-    /// DomUpper: (x <= v) => (x != v+1)  
+    ///
+    /// DomUpper: (x <= v) => (x != v+1)
     /// DomLower: (x >= v) => (x != v-1)
-    /// DomSingleton: (x >= v) & (x <= v) => (x = v)  
+    /// DomSingleton: (x >= v) & (x <= v) => (x = v)
     pub fn propagate_domain_event(
         &mut self,
         v: SignedVar,
@@ -1142,7 +1142,7 @@ mod tests {
         };
         let explainer = &mut SingleTheoryExplainer(&mut theory);
         let clause = match contradiction {
-            Contradiction::InvalidUpdate(up) => domains.clause_for_invalid_update(up, explainer),
+            Contradiction::InvalidUpdate(up) => domains.clause_for_invalid_inferrence(up, explainer),
             Contradiction::Explanation(expl) => domains.refine_explanation(expl, explainer),
         };
         println!("ab: {ab:?}, bc: {bc:?}, ac: {ac:?}");

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -1029,7 +1029,6 @@ impl<Lbl> Backtrack for Solver<Lbl> {
     fn restore_last(&mut self) {
         assert!(self.decision_level > DecLvl::ROOT);
         self.restore(self.decision_level - 1);
-        self.decision_level -= 1;
     }
 
     fn restore(&mut self, saved_id: DecLvl) {

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -584,12 +584,12 @@ impl<Lbl: Label> Solver<Lbl> {
                         let unsat_core = self.model.state.extract_unsat_core(&conflict, &mut self.reasoners);
                         return Ok(Err(unsat_core));
                     }
-                },
+                }
                 Err(failed) => {
                     let conflict = self.model.state.clause_for_invalid_update(failed, &mut self.reasoners);
                     let unsat_core = self.model.state.extract_unsat_core(&conflict, &mut self.reasoners);
                     return Ok(Err(unsat_core));
-                },
+                }
             }
         }
         let last_assumption_dec_lvl = self.current_decision_level();
@@ -740,13 +740,10 @@ impl<Lbl: Label> Solver<Lbl> {
 
                 // force future solutions to improve on this one
                 if minimize {
-//                    must_improve_lits = vec![objective.lt_lit(objective_value)];
                     must_improve_lits.push(objective.lt_lit(objective_value));
                 } else {
-//                    must_improve_lits = vec![objective.gt_lit(objective_value)];
                     must_improve_lits.push(objective.gt_lit(objective_value));
                 }
-
             }
         }
     }
@@ -766,7 +763,7 @@ impl<Lbl: Label> Solver<Lbl> {
 
     pub fn assume(&mut self, assumption: Lit) -> Result<bool, InvalidUpdate> {
         assert!(
-            self.model.state.decisions().is_empty(), // FIXME: find a more efficient way to check ?..
+            self.model.state.decisions().is_empty(),
             "Not allowed to make assumptions after solver already started making decisions (i.e. started solving) !",
         );
         self.save_state();

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -581,13 +581,18 @@ impl<Lbl: Label> Solver<Lbl> {
             match self.assume(lit) {
                 Ok(_) => {
                     if let Err(conflict) = self.propagate_and_backtrack_to_consistent(self.current_decision_level()) {
-                        let unsat_core = self.model.state.extract_unsat_core(&conflict, &mut self.reasoners);
+                        let unsat_core = self
+                            .model
+                            .state
+                            .extract_unsat_core_after_conflict(conflict, &mut self.reasoners);
                         return Ok(Err(unsat_core));
                     }
                 }
                 Err(failed) => {
-                    let conflict = self.model.state.clause_for_invalid_update(failed, &mut self.reasoners);
-                    let unsat_core = self.model.state.extract_unsat_core(&conflict, &mut self.reasoners);
+                    let unsat_core = self
+                        .model
+                        .state
+                        .extract_unsat_core_after_invalid_update(failed, &mut self.reasoners);
                     return Ok(Err(unsat_core));
                 }
             }
@@ -597,7 +602,10 @@ impl<Lbl: Label> Solver<Lbl> {
             SolveResult::AtSolution => Ok(Ok(Arc::new(self.model.state.clone()))),
             SolveResult::ExternalSolution(s) => Ok(Ok(s)),
             SolveResult::Unsat(conflict) => {
-                let unsat_core = self.model.state.extract_unsat_core(&conflict, &mut self.reasoners);
+                let unsat_core = self
+                    .model
+                    .state
+                    .extract_unsat_core_after_conflict(conflict, &mut self.reasoners);
                 Ok(Err(unsat_core))
             }
         }

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -838,7 +838,7 @@ impl<Lbl: Label> Solver<Lbl> {
                 Err(self
                     .model
                     .state
-                    .extract_unsat_core_after_invalid_update(invalid_update, &mut self.reasoners))
+                    .extract_unsat_core_after_invalid_assumption(invalid_update, &mut self.reasoners))
             }
         }
     }
@@ -1056,9 +1056,10 @@ impl<Lbl: Label> Solver<Lbl> {
                         self.brancher.pre_conflict_analysis(&self.model);
                         // contradiction, learn clause and exit
                         let clause = match contradiction {
-                            Contradiction::InvalidUpdate(fail) => {
-                                self.model.state.clause_for_invalid_update(fail, &mut self.reasoners)
-                            }
+                            Contradiction::InvalidUpdate(fail) => self
+                                .model
+                                .state
+                                .clause_for_invalid_inferrence(fail, &mut self.reasoners),
                             Contradiction::Explanation(expl) => {
                                 self.model.state.refine_explanation(expl, &mut self.reasoners)
                             }

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -569,7 +569,7 @@ impl<Lbl: Label> Solver<Lbl> {
         // TODO? let start_time = Instant::now();
         // TODO? let start_cycles = StartCycleCount::now();
 
-        match self.propagate_and_backtrack_to_consistent(DecLvl::ROOT) {
+        match self.propagate_and_backtrack_to_consistent(self.current_decision_level()) {
             Ok(()) => (),
             Err(conflict) => {
                 debug_assert!(conflict.is_empty());


### PR DESCRIPTION
Fix: #20 

Simple MiniSat-like assumption-based solving. Allows for incremental solving as well. After assumption solving, resetting the solver to the desired (often root / initial) decision level must be performed manually.