### PR TITLE
Export Solver and Theory Statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "num-integer",
  "num-rational",
  "rand",
+ "serde",
  "smallvec",
  "streaming-iterator",
  "tracing",
@@ -241,6 +242,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aries",
+ "serde_json",
  "structopt",
  "varisat-dimacs",
  "varisat-formula",

--- a/examples/sat/Cargo.toml
+++ b/examples/sat/Cargo.toml
@@ -11,7 +11,7 @@ aries = { path = "../../solver" }
 varisat-dimacs = "0.2.2"
 varisat-formula = "0.2.2"
 zip = { default-features = false, features = ["deflate"], version = "2.1.3" }
-
+serde_json = "*"
 
 [[bin]]
 name = "aries-sat"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 
 [features]
 
+# if enabled, solver and theory statistics may be exported and imported using serde
+export_stats = [ "dep:serde" ]
+
 # If enabled, will instruct the the solver to count cpu cycles at various point of its execution.
 # The implementation relies to time-stamp counter and intrinsic for the x86_64 platform.
 # If the target platform is not supported, activating this feature will have no effects.
@@ -30,6 +33,7 @@ lru = "0.12.3"
 rand = { workspace = true }
 num-rational = { workspace = true }
 hashbrown = "0.15"
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [features]
 
 # if enabled, solver and theory statistics may be exported and imported using serde
-export_stats = [ "dep:serde" ]
+export_stats = [ "dep:serde", "serde/serde_derive" ]
 
 # If enabled, will instruct the the solver to count cpu cycles at various point of its execution.
 # The implementation relies to time-stamp counter and intrinsic for the x86_64 platform.

--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -19,6 +19,7 @@ use crate::model::lang::mul::NFEqVarMulLit;
 use crate::reasoners::cp::linear::{LinearSumLeq, SumElem};
 use crate::reasoners::cp::max::AtLeastOneGeq;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
+use crate::utils::SnapshotStatistics;
 use anyhow::Context;
 use mul::VarEqVarMulLit;
 use set::IterableRefSet;
@@ -232,6 +233,30 @@ impl Theory for Cp {
 
     fn clone_box(&self) -> Box<dyn Theory> {
         Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct CpStatsSnapshot {
+    pub num_constraints: usize,
+    pub num_propagations: u64,
+}
+
+impl std::fmt::Display for CpStatsSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "# constraints: {}", self.num_constraints)?;
+        writeln!(f, "# propagations: {}", self.num_propagations)
+    }
+}
+
+impl SnapshotStatistics for Cp {
+    type Stats = CpStatsSnapshot;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        Self::Stats {
+            num_constraints: self.constraints.len(),
+            num_propagations: self.stats.num_propagations,
+        }
     }
 }
 

--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -236,6 +236,7 @@ impl Theory for Cp {
     }
 }
 
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CpStatsSnapshot {
     pub num_constraints: usize,

--- a/solver/src/reasoners/eq/dense.rs
+++ b/solver/src/reasoners/eq/dense.rs
@@ -876,8 +876,9 @@ impl Theory for DenseEqTheory {
     }
 }
 
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct DenseEqTheoryStatsSnapshot {
+pub struct EqTheoryStatsSnapshot {
     pub num_nodes: usize,
     pub num_edge_propagations: usize,
     pub num_edge_propagations_pos: usize,
@@ -891,7 +892,7 @@ pub struct DenseEqTheoryStatsSnapshot {
     pub num_edge_propagation2_neg_pos: usize,
 }
 
-impl std::fmt::Display for DenseEqTheoryStatsSnapshot {
+impl std::fmt::Display for EqTheoryStatsSnapshot {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "num nodes: {}", self.num_nodes)?;
         writeln!(f, "num edge props1 {}", self.num_edge_propagations)?;
@@ -908,7 +909,7 @@ impl std::fmt::Display for DenseEqTheoryStatsSnapshot {
 }
 
 impl SnapshotStatistics for DenseEqTheory {
-    type Stats = DenseEqTheoryStatsSnapshot;
+    type Stats = EqTheoryStatsSnapshot;
 
     fn snapshot_statistics(&self) -> Self::Stats {
         Self::Stats {

--- a/solver/src/reasoners/eq/dense.rs
+++ b/solver/src/reasoners/eq/dense.rs
@@ -6,6 +6,7 @@ use crate::model::{Label, Model};
 use crate::reasoners::eq::domain;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
 use crate::reif::ReifExpr;
+use crate::utils::SnapshotStatistics;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
@@ -872,6 +873,57 @@ impl Theory for DenseEqTheory {
 
     fn clone_box(&self) -> Box<dyn Theory> {
         Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DenseEqTheoryStatsSnapshot {
+    pub num_nodes: usize,
+    pub num_edge_propagations: usize,
+    pub num_edge_propagations_pos: usize,
+    pub num_edge_propagations_neg: usize,
+    pub num_edge_propagation1_pos_pos: usize,
+    pub num_edge_propagation1_pos_neg: usize,
+    pub num_edge_propagation1_neg_pos: usize,
+    pub num_edge_propagation1_effective: usize,
+    pub num_edge_propagation2_pos_pos: usize,
+    pub num_edge_propagation2_pos_neg: usize,
+    pub num_edge_propagation2_neg_pos: usize,
+}
+
+impl std::fmt::Display for DenseEqTheoryStatsSnapshot {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "num nodes: {}", self.num_nodes)?;
+        writeln!(f, "num edge props1 {}", self.num_edge_propagations)?;
+        writeln!(f, "num edge props+ {}", self.num_edge_propagations_pos)?;
+        writeln!(f, "num edge props- {}", self.num_edge_propagations_neg)?;
+        writeln!(f, "num edge props1 ++  {}", self.num_edge_propagation1_pos_pos)?;
+        writeln!(f, "num edge props1 +-  {}", self.num_edge_propagation1_pos_neg)?;
+        writeln!(f, "num edge props1 -+  {}", self.num_edge_propagation1_neg_pos)?;
+        writeln!(f, "num edge props1 eff  {}", self.num_edge_propagation1_effective)?;
+        writeln!(f, "num edge props2 ++  {}", self.num_edge_propagation2_pos_pos)?;
+        writeln!(f, "num edge props2 +-  {}", self.num_edge_propagation2_pos_neg)?;
+        writeln!(f, "num edge props2 -+  {}", self.num_edge_propagation2_neg_pos)
+    }
+}
+
+impl SnapshotStatistics for DenseEqTheory {
+    type Stats = DenseEqTheoryStatsSnapshot;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        Self::Stats {
+            num_nodes: self.graph.nodes_ordered.len(),
+            num_edge_propagations: self.stats.num_edge_propagations,
+            num_edge_propagations_pos: self.stats.num_edge_propagations_pos,
+            num_edge_propagations_neg: self.stats.num_edge_propagations_neg,
+            num_edge_propagation1_pos_pos: self.stats.num_edge_propagation1_pos_pos,
+            num_edge_propagation1_pos_neg: self.stats.num_edge_propagation1_pos_neg,
+            num_edge_propagation1_neg_pos: self.stats.num_edge_propagation1_neg_pos,
+            num_edge_propagation1_effective: self.stats.num_edge_propagation1_effective,
+            num_edge_propagation2_pos_pos: self.stats.num_edge_propagation2_pos_pos,
+            num_edge_propagation2_pos_neg: self.stats.num_edge_propagation2_pos_neg,
+            num_edge_propagation2_neg_pos: self.stats.num_edge_propagation2_neg_pos,
+        }
     }
 }
 

--- a/solver/src/reasoners/eq/split.rs
+++ b/solver/src/reasoners/eq/split.rs
@@ -1,7 +1,7 @@
 use crate::backtrack::{Backtrack, DecLvl, DecisionLevelTracker};
 use crate::core::state::{Domains, DomainsSnapshot, Explanation, InferenceCause};
 use crate::core::{IntCst, Lit, VarRef};
-use crate::reasoners::eq::{DenseEqTheory, DenseEqTheoryStatsSnapshot, Node, ReifyEq};
+use crate::reasoners::eq::{DenseEqTheory, EqTheoryStatsSnapshot, Node, ReifyEq};
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
 use crate::utils::SnapshotStatistics;
 use itertools::Itertools;
@@ -19,12 +19,12 @@ pub struct SplitEqTheory {
 }
 
 impl SnapshotStatistics for SplitEqTheory {
-    type Stats = DenseEqTheoryStatsSnapshot;
+    type Stats = EqTheoryStatsSnapshot;
 
     fn snapshot_statistics(&self) -> Self::Stats {
         self.parts()
             .map(|part| part.snapshot_statistics())
-            .reduce(|sum, next| DenseEqTheoryStatsSnapshot {
+            .reduce(|sum, next| EqTheoryStatsSnapshot {
                 num_nodes: sum.num_nodes + next.num_nodes,
                 num_edge_propagations: sum.num_edge_propagations + next.num_edge_propagations,
                 num_edge_propagations_pos: sum.num_edge_propagations_pos + next.num_edge_propagations_pos,

--- a/solver/src/reasoners/sat/sat_solver.rs
+++ b/solver/src/reasoners/sat/sat_solver.rs
@@ -6,6 +6,7 @@ use crate::core::*;
 use crate::model::extensions::DisjunctionExt;
 use crate::reasoners::sat::clauses::*;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
+use crate::utils::SnapshotStatistics;
 use itertools::Itertools;
 use smallvec::alloc::collections::VecDeque;
 
@@ -718,6 +719,30 @@ impl Backtrack for SatSolver {
     fn restore_last(&mut self) {
         let locks = &mut self.locks;
         self.trail.restore_last_with(|SatEvent::Lock(cl)| locks.unlock(cl));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SatSolverStatsSnapshot {
+    pub num_clauses: usize,
+    pub propagations: u64,
+}
+
+impl std::fmt::Display for SatSolverStatsSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "DB size              : {}", self.num_clauses)?;
+        writeln!(f, "Num unit propagations: {}", self.propagations)
+    }
+}
+
+impl SnapshotStatistics for SatSolver {
+    type Stats = SatSolverStatsSnapshot;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        SatSolverStatsSnapshot {
+            num_clauses: self.clauses.num_clauses(),
+            propagations: self.stats.propagations,
+        }
     }
 }
 

--- a/solver/src/reasoners/sat/sat_solver.rs
+++ b/solver/src/reasoners/sat/sat_solver.rs
@@ -722,6 +722,7 @@ impl Backtrack for SatSolver {
     }
 }
 
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SatSolverStatsSnapshot {
     pub num_clauses: usize,

--- a/solver/src/reasoners/stn/theory.rs
+++ b/solver/src/reasoners/stn/theory.rs
@@ -115,6 +115,7 @@ struct Stats {
     num_theory_deactivations: u64,
 }
 
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StnStatSnapshot {
     pub num_nodes: u32,

--- a/solver/src/reasoners/stn/theory.rs
+++ b/solver/src/reasoners/stn/theory.rs
@@ -10,6 +10,7 @@ use crate::core::state::*;
 use crate::core::*;
 use crate::reasoners::stn::theory::Event::EdgeActivated;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
+use crate::utils::SnapshotStatistics;
 use contraint_db::*;
 use distances::{Graph, StnGraph};
 use edges::*;
@@ -112,6 +113,29 @@ struct Stats {
     num_bound_edge_deactivation: u64,
     num_theory_propagations: u64,
     num_theory_deactivations: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StnStatSnapshot {
+    pub num_nodes: u32,
+    pub num_propagator_groups: usize,
+    pub num_propagations: u64,
+    pub bound_updates: u64,
+    pub num_bound_edge_deactivation: u64,
+    pub num_theory_propagations: u64,
+    pub num_theory_deactivations: u64,
+}
+
+impl std::fmt::Display for StnStatSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "# nodes: {}", self.num_nodes)?;
+        writeln!(f, "# propagators: {}", self.num_propagator_groups)?;
+        writeln!(f, "# propagations: {}", self.num_propagations)?;
+        writeln!(f, "# domain updates: {}", self.bound_updates)?;
+        writeln!(f, "# bounds deactivations: {}", self.num_bound_edge_deactivation)?;
+        writeln!(f, "# theory propagations: {}", self.num_theory_propagations)?;
+        writeln!(f, "# theory deactivations: {}", self.num_theory_deactivations)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -960,6 +984,22 @@ impl Backtrack for StnTheory {
 
     fn restore_last(&mut self) {
         self.undo_to_last_backtrack_point();
+    }
+}
+
+impl SnapshotStatistics for StnTheory {
+    type Stats = StnStatSnapshot;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        StnStatSnapshot {
+            num_nodes: self.num_nodes(),
+            num_propagator_groups: self.constraints.num_propagator_groups(),
+            num_propagations: self.stats.num_propagations,
+            bound_updates: self.stats.bound_updates,
+            num_bound_edge_deactivation: self.stats.num_bound_edge_deactivation,
+            num_theory_propagations: self.stats.num_theory_propagations,
+            num_theory_deactivations: self.stats.num_theory_deactivations,
+        }
     }
 }
 

--- a/solver/src/reasoners/tautologies.rs
+++ b/solver/src/reasoners/tautologies.rs
@@ -79,14 +79,15 @@ impl Theory for Tautologies {
     }
 }
 
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct TautologiesStatSnapshot;
+
 impl std::fmt::Display for TautologiesStatSnapshot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", std::any::type_name::<Self>())
     }
 }
-
 
 impl SnapshotStatistics for Tautologies {
     type Stats = TautologiesStatSnapshot;

--- a/solver/src/reasoners/tautologies.rs
+++ b/solver/src/reasoners/tautologies.rs
@@ -2,6 +2,7 @@ use crate::backtrack::{Backtrack, DecLvl};
 use crate::core::state::{Cause, Domains, DomainsSnapshot, Explanation, InferenceCause};
 use crate::core::Lit;
 use crate::reasoners::{Contradiction, ReasonerId, Theory};
+use crate::utils::SnapshotStatistics;
 
 /// A reasoner that holds a set of tautologies (single literals that are known to be true)
 /// and propagates them at every decision level.
@@ -75,5 +76,22 @@ impl Theory for Tautologies {
 
     fn clone_box(&self) -> Box<dyn Theory> {
         Box::new(self.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TautologiesStatSnapshot;
+impl std::fmt::Display for TautologiesStatSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", std::any::type_name::<Self>())
+    }
+}
+
+
+impl SnapshotStatistics for Tautologies {
+    type Stats = TautologiesStatSnapshot;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        TautologiesStatSnapshot
     }
 }

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -13,6 +13,7 @@ use crate::solver::parallel::signals::{InputSignal, InputStream, SolverOutput, S
 use crate::solver::search::{default_brancher, Decision, SearchControl};
 use crate::solver::stats::Stats;
 use crate::utils::cpu_time::StartCycleCount;
+use crate::utils::SnapshotStatistics;
 use crossbeam_channel::Sender;
 use env_param::EnvParam;
 use itertools::Itertools;
@@ -933,6 +934,14 @@ impl<Lbl: Label> Solver<Lbl> {
             println!("====== {i} =====");
             th.print_stats();
         }
+    }
+}
+
+impl<Lbl> SnapshotStatistics for Solver<Lbl> {
+    type Stats = Stats;
+
+    fn snapshot_statistics(&self) -> Self::Stats {
+        self.stats.clone()
     }
 }
 

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -22,6 +22,8 @@ use std::sync::Arc;
 use std::time::Instant;
 use tracing::instrument;
 
+use super::stats::{SolverModuleStatSnapshot, SolverModuleStats, SolverStatsSnapshot};
+
 /// If true, decisions will be logged to the standard output.
 static LOG_DECISIONS: EnvParam<bool> = EnvParam::new("ARIES_LOG_DECISIONS", "false");
 
@@ -938,10 +940,54 @@ impl<Lbl: Label> Solver<Lbl> {
 }
 
 impl<Lbl> SnapshotStatistics for Solver<Lbl> {
-    type Stats = Stats;
+    type Stats = SolverStatsSnapshot;
 
     fn snapshot_statistics(&self) -> Self::Stats {
-        self.stats.clone()
+        let modules = SolverModuleStatSnapshot {
+            sat: SolverModuleStats {
+                propagation_cycles: self.stats[ReasonerId::Sat].propagation_time.count(),
+                conflicts: self.stats[ReasonerId::Sat].conflicts,
+                propagation_loops: self.stats[ReasonerId::Sat].propagation_loops,
+                internal: self.reasoners.sat.snapshot_statistics(),
+            },
+            diff: SolverModuleStats {
+                propagation_cycles: self.stats[ReasonerId::Diff].propagation_time.count(),
+                conflicts: self.stats[ReasonerId::Diff].conflicts,
+                propagation_loops: self.stats[ReasonerId::Sat].propagation_loops,
+                internal: self.reasoners.diff.snapshot_statistics(),
+            },
+            cp: SolverModuleStats {
+                propagation_cycles: self.stats[ReasonerId::Cp].propagation_time.count(),
+                conflicts: self.stats[ReasonerId::Cp].conflicts,
+                propagation_loops: self.stats[ReasonerId::Cp].propagation_loops,
+                internal: self.reasoners.cp.snapshot_statistics(),
+            },
+            eq: SolverModuleStats {
+                propagation_cycles: self.stats[ReasonerId::Eq(0)].propagation_time.count(),
+                conflicts: self.stats[ReasonerId::Eq(0)].conflicts,
+                propagation_loops: self.stats[ReasonerId::Eq(0)].propagation_loops,
+                internal: self.reasoners.eq.snapshot_statistics(),
+            },
+            tautologies: SolverModuleStats {
+                propagation_cycles: self.stats[ReasonerId::Tautologies].propagation_time.count(),
+                conflicts: self.stats[ReasonerId::Tautologies].conflicts,
+                propagation_loops: self.stats[ReasonerId::Tautologies].propagation_loops,
+                internal: self.reasoners.tautologies.snapshot_statistics(),
+            },
+        };
+
+        Self::Stats {
+            init_time: self.stats.init_time,
+            init_cycles: self.stats.init_cycles.count(),
+            solve_time: self.stats.solve_time,
+            solve_cycles: self.stats.solve_cycles.count(),
+            num_decisions: self.stats.num_decisions,
+            num_conflicts: self.stats.num_conflicts,
+            num_restarts: self.stats.num_restarts,
+            num_solutions: self.stats.num_solutions,
+            propagation_cycles: self.stats.propagation_time.count(),
+            modules,
+        }
     }
 }
 

--- a/solver/src/solver/stats.rs
+++ b/solver/src/solver/stats.rs
@@ -1,5 +1,10 @@
 use crate::backtrack::DecLvl;
 use crate::core::{IntCst, Lit};
+use crate::reasoners::cp::CpStatsSnapshot;
+use crate::reasoners::eq::EqTheoryStatsSnapshot;
+use crate::reasoners::sat::SatSolverStatsSnapshot;
+use crate::reasoners::stn::theory::StnStatSnapshot;
+use crate::reasoners::tautologies::TautologiesStatSnapshot;
 use crate::reasoners::ReasonerId;
 use crate::reasoners::REASONERS;
 use crate::utils::cpu_time::*;
@@ -231,4 +236,43 @@ impl IndexMut<ReasonerId> for Stats {
     fn index_mut(&mut self, index: ReasonerId) -> &mut Self::Output {
         self.per_module_stat.get_mut(&index).unwrap()
     }
+}
+
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug)]
+pub struct SolverModuleStatSnapshot {
+    pub sat: SolverModuleStats<SatSolverStatsSnapshot>,
+    pub diff: SolverModuleStats<StnStatSnapshot>,
+    pub cp: SolverModuleStats<CpStatsSnapshot>,
+    pub eq: SolverModuleStats<EqTheoryStatsSnapshot>,
+    pub tautologies: SolverModuleStats<TautologiesStatSnapshot>,
+}
+
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug)]
+pub struct SolverStatsSnapshot {
+    pub init_time: Duration,
+    pub init_cycles: Option<u64>,
+
+    pub solve_time: Duration,
+    pub solve_cycles: Option<u64>,
+
+    pub num_decisions: u64,
+    pub num_conflicts: u64,
+    pub num_restarts: u64,
+    pub num_solutions: u64,
+
+    pub propagation_cycles: Option<u64>,
+    pub modules: SolverModuleStatSnapshot,
+}
+
+#[cfg_attr(feature = "export_stats", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Default, Debug)]
+pub struct SolverModuleStats<InteranlStatsT: std::fmt::Debug> {
+    pub propagation_cycles: Option<u64>,
+    pub conflicts: u64,
+    pub propagation_loops: u64,
+
+    /// Statistics that were recorded by this module.
+    pub internal: InteranlStatsT,
 }

--- a/solver/src/utils/mod.rs
+++ b/solver/src/utils/mod.rs
@@ -1,6 +1,9 @@
 pub(crate) mod cpu_time;
 pub mod input;
 
+mod statistics;
+pub use statistics::*;
+
 use std::fmt::{Display, Error, Formatter};
 
 /// A custom type to extract the formatter and feed it to formal_impl

--- a/solver/src/utils/statistics.rs
+++ b/solver/src/utils/statistics.rs
@@ -1,10 +1,8 @@
-
-
 /// Implementors of this trait can export a snapshot of their runtime statistics.
 /// The exported data must be able to _at least_ be formatted using std::fmt::Display.
 /// Ideally, it should also implement serde traits when `export_stats` feature is enabled.
 pub trait SnapshotStatistics {
-    type Stats: Sized + std::fmt::Display;
+    type Stats: Sized + std::fmt::Debug;
 
     fn snapshot_statistics(&self) -> Self::Stats;
 }

--- a/solver/src/utils/statistics.rs
+++ b/solver/src/utils/statistics.rs
@@ -1,0 +1,10 @@
+
+
+/// Implementors of this trait can export a snapshot of their runtime statistics.
+/// The exported data must be able to _at least_ be formatted using std::fmt::Display.
+/// Ideally, it should also implement serde traits when `export_stats` feature is enabled.
+pub trait SnapshotStatistics {
+    type Stats: Sized + std::fmt::Display;
+
+    fn snapshot_statistics(&self) -> Self::Stats;
+}


### PR DESCRIPTION
Addresses #18.

This PR adds a trait, `SnapshotStatistics`, and a collection of `*StatsSnapshot` data structures which generally mirror the various `Stats` data structures for each reasoner as well as the main `Solver` struct.

I chose to define new stat types because the existing `reasoners::*::Stat` types seemed particularly suited to recording statistics, and didn't include all the information printed with the `print_stats()` functions. The `*StatsSnapshot` types are intended to have a field corresponding to each line from `print_stats()` , and generally be simple, static structures which are easy to export and reason about. These structures also implement `serde` traits, when enabled.

The trait has a straightforward definition, just returning _some_ structure with a few basic constraints:
```rs
pub trait SnapshotStatistics {
    type Stats: Sized + std::fmt::Debug;

    fn snapshot_statistics(&self) -> Self::Stats;
}
```
Each component implementing `Theory` now implements `SnapshotStatistics`, with it's own  `*StatsSnapshot` as `Stats`.

----

As an example (and test) this PR also adds an option to export the `aries-sat`'s solver stats as JSON. 