### PR TITLE
Flatzinc CI fix

### DIFF
--- a/.github/workflows/aries.yml
+++ b/.github/workflows/aries.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: plaans/mzn-problems
+          ref: v1
           path: mzn-problems
       - name: Compile aries_fzn (optimized + debug)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ flamegraph.svg
 perf.data
 perf.data.old
 examples/sat/instances/*.cnf
+aries_fzn/share/aries_fzn
 __pycache__/
 *.profraw
 lcov.info


### PR DESCRIPTION
- Added tag reference to mzn-problems checkout in minizinc CI job.
- Added aries_fzn binary to gitignore.