### PR TITLE
Don't depend on `[!Default; 0]: Default` impl

### DIFF
--- a/solver/src/reasoners/cp/mod.rs
+++ b/solver/src/reasoners/cp/mod.rs
@@ -34,7 +34,6 @@ use std::collections::{HashMap, HashSet};
 #[derive(Clone, Default)]
 pub struct Watches {
     propagations: RefMap<SignedVar, Vec<PropagatorId>>,
-    empty: [PropagatorId; 0],
 }
 
 impl Watches {
@@ -71,7 +70,7 @@ impl Watches {
     /// Returns all propagators
     fn get_ub_watches(&self, var: impl Into<SignedVar>) -> &[PropagatorId] {
         let var = var.into();
-        self.propagations.get(var).map(|v| v.as_slice()).unwrap_or(&self.empty)
+        self.propagations.get(var).map(|v| v.as_slice()).unwrap_or(&[])
     }
 }
 


### PR DESCRIPTION
There are plans to remove the unconditional `[T; 0]: Default` impl (where `T` doesn't necessarily implement `Default`) from the standard library (see https://github.com/rust-lang/rust/pull/145457). That is a breaking change that would affect this crate.

This PR fixes this by removing a dependency on that impl.

See commit description for why this works.