### PR TITLE
ci(fzn): pin minizinc version to a known one

### DIFF
--- a/.github/workflows/aries.yml
+++ b/.github/workflows/aries.yml
@@ -73,7 +73,7 @@ jobs:
           python-version: "3.10"
       - name: Install Minizinc
         run: |
-          sudo snap install minizinc --classic
+          sudo snap install minizinc --classic --revision 1222
           minizinc --version
           minizinc --solvers
           printenv MZN_SOLVER_PATH


### PR DESCRIPTION
Apparently the one released on 24/04/2026 had a bug and made the CI
fall.
This just reverts to an earlier one.
