### PR TITLE
feat(datalog): support arbitrary-arity predicates

### DIFF
--- a/utils/datalog/src/rules.rs
+++ b/utils/datalog/src/rules.rs
@@ -415,7 +415,39 @@ impl Pattern {
             3 => self.compiled::<3>().all_bindings(table.rows_sized(), out),
             4 => self.compiled::<4>().all_bindings(table.rows_sized(), out),
             5 => self.compiled::<5>().all_bindings(table.rows_sized(), out),
-            _ => unimplemented!(),
+            _ => {
+                let mut bindings = TableBuff::new(out.len());
+                let mut out_row = Vec::from(out);
+                for row in table.rows() {
+                    if self.matches(row) {
+                        self.bind(row, &mut out_row);
+                        bindings.push(&out_row);
+                    }
+                }
+                bindings
+            }
+        }
+    }
+
+    fn matches(&self, data: &[Sym]) -> bool {
+        debug_assert_eq!(self.pattern.len(), data.len());
+        for &[id1, id2] in &self.equalities {
+            if data[id1] != data[id2] {
+                return false;
+            }
+        }
+        self.pattern
+            .iter()
+            .copied()
+            .zip(data.iter().copied())
+            .all(|(pat, sym)| pat < 0 || (pat as u32) == sym)
+    }
+    fn bind(&self, row: &[Sym], out: &mut [u32]) {
+        debug_assert!(self.matches(row));
+        for (i, pat) in self.pattern.iter().copied().enumerate() {
+            if let Some(var) = Self::as_var(pat) {
+                out[var as usize] = row[i];
+            }
         }
     }
 }

--- a/utils/datalog/src/rules.rs
+++ b/utils/datalog/src/rules.rs
@@ -519,7 +519,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_pattern() {
+    fn test_pattern_spec() {
         let mut table = [
             [1, 2, 1],
             [1, 2, 2],
@@ -542,8 +542,6 @@ mod test {
         ];
         table.sort();
 
-        use Arg::*;
-
         let check_matches = |pattern: [Arg; 3], expected: &[Fact<3>]| {
             let pattern = Pattern::new(pattern.as_slice());
             let pattern = pattern.compiled();
@@ -551,6 +549,8 @@ mod test {
             let expected = expected.iter().cloned().sorted().collect_vec();
             assert_eq!(matches, expected)
         };
+
+        use Arg::*;
 
         check_matches([Var(0), Var(1), Sym(3)], &[[1, 2, 3], [2, 2, 3], [1, 3, 3]]);
 
@@ -561,6 +561,50 @@ mod test {
 
         // let pattern = Pattern::new([Var(0), Sym(1), Var(0)]);
         // let bindings: &mut [u32] = &mut [0; 2];
+    }
+
+    #[test]
+    fn test_pattern_generic() {
+        let table = Table::new_from_flat(
+            6,
+            vec![
+                1, 2, 3, 10, 5, 20, 2, 2, 3, 11, 5, 21, 1, 3, 3, 12, 5, 22, 2, 2, 3, 30, 5, 30, 4, 4, 3, 40, 5, 40, 1,
+                5, 1, 50, 5, 50, 2, 6, 2, 60, 5, 60, 1, 3, 6, 70, 5, 70,
+            ],
+        );
+
+        let check_matches = |pattern: &[Arg], expected: &[&[_]]| {
+            let pattern = Pattern::new(pattern);
+            let num_vars = pattern.vars().unique().count();
+            let empty_bindings = vec![super::Sym::MAX; num_vars];
+            let bindings = pattern.all_bindings(&table, &empty_bindings);
+            let mut results: Vec<Vec<_>> = bindings.rows().map(|r| r.to_vec()).collect();
+            results.sort();
+            let mut expected: Vec<Vec<_>> = expected.iter().map(|e| e.to_vec()).collect();
+            expected.sort();
+            assert_eq!(results, expected)
+        };
+
+        use Arg::*;
+
+        check_matches(
+            &[Var(0), Var(1), Sym(3), Var(2), Sym(5), Var(3)],
+            &[
+                &[1, 2, 10, 20],
+                &[2, 2, 11, 21],
+                &[1, 3, 12, 22],
+                &[2, 2, 30, 30],
+                &[4, 4, 40, 40],
+            ],
+        );
+
+        check_matches(&[Var(0), Var(0), Sym(3), Var(1), Sym(5), Var(1)], &[&[2, 30], &[4, 40]]);
+        check_matches(
+            &[Var(0), Var(1), Var(0), Var(2), Sym(5), Var(2)],
+            &[&[1, 5, 50], &[2, 6, 60]],
+        );
+        check_matches(&[Sym(1), Sym(3), Sym(6), Var(0), Sym(5), Var(0)], &[&[70]]);
+        check_matches(&[Sym(1), Sym(3), Sym(0), Var(0), Sym(5), Var(0)], &[]);
     }
 
     #[test]

--- a/utils/datalog/src/tables.rs
+++ b/utils/datalog/src/tables.rs
@@ -1,4 +1,3 @@
-use core::todo;
 use std::{
     cell::{Ref, RefCell},
     rc::Rc,
@@ -144,7 +143,16 @@ impl Table {
             3 => Table::new(Self::into_chunks::<3>(data)),
             4 => Table::new(Self::into_chunks::<4>(data)),
             5 => Table::new(Self::into_chunks::<5>(data)),
-            _ => todo!(),
+            n => {
+                let mut rows: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
+                rows.sort_unstable();
+                rows.dedup();
+                Table {
+                    num_columns: n,
+                    data: rows.into_iter().flat_map(|b| b.into_vec()).collect(),
+                    has_unit: false,
+                }
+            }
         }
     }
 
@@ -180,7 +188,12 @@ impl Table {
                 .into_flattened(),
             5 => crate::merge::merge_unique(Self::into_chunks::<5>(data), Self::into_chunks(recent.data))
                 .into_flattened(),
-            _ => todo!(),
+            n => {
+                let a_rows: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
+                let b_rows: Vec<Box<[Sym]>> = recent.data.chunks(n).map(Box::from).collect();
+                let merged = crate::merge::merge_unique(a_rows, b_rows);
+                merged.into_iter().flat_map(|b| b.into_vec()).collect()
+            }
         };
         self.data = data
     }
@@ -240,7 +253,23 @@ impl Table {
             3 => self.retain_distinct_spec::<3>(reference),
             4 => self.retain_distinct_spec::<4>(reference),
             5 => self.retain_distinct_spec::<5>(reference),
-            _ => todo!(),
+            n => {
+                let data = std::mem::take(&mut self.data);
+                let mut data: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
+                let mut reference = reference.data.chunks(n);
+                let mut next_ref = reference.next();
+                data.retain(|row| {
+                    while let Some(r) = next_ref {
+                        if r < row.as_ref() {
+                            next_ref = reference.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    next_ref.is_none_or(|r| r != row.as_ref())
+                });
+                self.data = data.into_iter().flat_map(|b| b.into_vec()).collect();
+            }
         }
     }
     /// Arity-specialized version of [`Self::retain_distinct`]

--- a/utils/datalog/src/tables.rs
+++ b/utils/datalog/src/tables.rs
@@ -192,7 +192,7 @@ impl Table {
                 let a_rows = into_chunks_generic(data, n);
                 let b_rows = into_chunks_generic(recent.data, n);
                 let merged = crate::merge::merge_unique(a_rows, b_rows);
-                merged.into_iter().flat_map(|b| b.into_vec()).collect()
+                into_flattened_generic(merged)
             }
         };
         self.data = data
@@ -268,7 +268,7 @@ impl Table {
                     }
                     next_ref.is_none_or(|r| r != row.as_ref())
                 });
-                self.data = data.into_iter().flat_map(|b| b.into_vec()).collect();
+                self.data = into_flattened_generic(data);
             }
         }
     }

--- a/utils/datalog/src/tables.rs
+++ b/utils/datalog/src/tables.rs
@@ -144,12 +144,12 @@ impl Table {
             4 => Table::new(Self::into_chunks::<4>(data)),
             5 => Table::new(Self::into_chunks::<5>(data)),
             n => {
-                let mut rows: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
+                let mut rows = into_chunks_generic(data, n);
                 rows.sort_unstable();
                 rows.dedup();
                 Table {
                     num_columns: n,
-                    data: rows.into_iter().flat_map(|b| b.into_vec()).collect(),
+                    data: into_flattened_generic(rows),
                     has_unit: false,
                 }
             }
@@ -189,8 +189,8 @@ impl Table {
             5 => crate::merge::merge_unique(Self::into_chunks::<5>(data), Self::into_chunks(recent.data))
                 .into_flattened(),
             n => {
-                let a_rows: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
-                let b_rows: Vec<Box<[Sym]>> = recent.data.chunks(n).map(Box::from).collect();
+                let a_rows = into_chunks_generic(data, n);
+                let b_rows = into_chunks_generic(recent.data, n);
                 let merged = crate::merge::merge_unique(a_rows, b_rows);
                 merged.into_iter().flat_map(|b| b.into_vec()).collect()
             }
@@ -255,7 +255,7 @@ impl Table {
             5 => self.retain_distinct_spec::<5>(reference),
             n => {
                 let data = std::mem::take(&mut self.data);
-                let mut data: Vec<Box<[Sym]>> = data.chunks(n).map(Box::from).collect();
+                let mut data = into_chunks_generic(data, n);
                 let mut reference = reference.data.chunks(n);
                 let mut next_ref = reference.next();
                 data.retain(|row| {
@@ -286,6 +286,13 @@ impl Table {
         });
         self.data = data.into_flattened();
     }
+}
+
+fn into_chunks_generic(data: Vec<Sym>, n: usize) -> Vec<Box<[Sym]>> {
+    data.chunks(n).map(Box::from).collect()
+}
+fn into_flattened_generic(data: Vec<Box<[Sym]>>) -> Vec<Sym> {
+    data.into_iter().flat_map(|b| b.into_vec()).collect()
 }
 
 /// A table to which elements can be added, either manually or as a result of running the program.


### PR DESCRIPTION
This provides support for predicates with an arbitrary number of parameters in `aries-datalog`.

This is a prerequisite for the grounder of [#226](https://github.com/plaans/aries/pull/226).