### PR TITLE
feat(datalog): add automatic rule normalization

### DIFF
--- a/utils/datalog/src/program.rs
+++ b/utils/datalog/src/program.rs
@@ -65,6 +65,7 @@ impl Program {
     ///
     /// `singleton_c` is a fresh arity-1 predicate that is interned (cached)
     /// per distinct `Arg::Sym(c)` and seeded with the single fact `singleton_c(c)`.
+    /// This is why this method borrows `self` as mutable.
     ///
     /// If `Arg::Sym(c)` is the `i`-th encountered constant in the head, then `v` is chosen to be
     /// the `i`-th integer in descending order starting from the maximum allowable value for `v`.
@@ -219,5 +220,32 @@ mod test {
             .borrow()
             .rows()
             .for_each(|row| println!("move{row:?}"));
+    }
+
+    #[test]
+    fn test_normalize_rule() {
+        let mut prog = Program::new();
+
+        let p = prog.new_predicate(2);
+        let q = prog.new_predicate(2);
+        let r = prog.new_predicate(1);
+
+        q.add([1, 10]);
+        q.add([2, 20]);
+        r.add([10]);
+
+        use Arg::*;
+
+        // p(1, ?x) :- q(?x, ?y), r(?y)
+        // Expect: p(1, 1) derived
+        prog.add_rule(Rule::new(
+            p.apply([Sym(1), Var(0)]),
+            [q.apply([Var(0), Var(1)]), r.apply([Var(1)])],
+        ));
+
+        prog.run();
+
+        let p_facts: Vec<Vec<_>> = p.stable.borrow().rows().map(|r| r.to_vec()).collect();
+        assert_eq!(p_facts, vec![vec![1, 1]]);
     }
 }

--- a/utils/datalog/src/program.rs
+++ b/utils/datalog/src/program.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::*;
 
 /// A program is a collection of predicates, facts and rules.
@@ -7,6 +9,9 @@ use crate::*;
 pub struct Program {
     vars: Vec<VarTable>,
     rules: Vec<Box<dyn RuleStep>>,
+
+    /// For a given symbol (key) stores the index of the interned / cached singleton predicate / table.
+    symbol_predicates_cache: HashMap<u32, usize>,
 }
 
 impl Program {
@@ -24,8 +29,23 @@ impl Program {
         table
     }
 
-    /// Adds a new rule to the program.
+    /// Number of predicates that have been added to the program.
+    pub fn num_predicates(&self) -> usize {
+        self.vars.len()
+    }
+    /// Returns a reference to the [`VarTable`] of the i-th predicate added to the program.
+    pub fn get_predicate(&self, i: usize) -> Option<&VarTable> {
+        self.vars.get(i)
+    }
+    /// Returns a reference to the [`VarTable`] of the i-th predicate added to the program.
+    pub fn get_predicate_mut(&mut self, i: usize) -> Option<&mut VarTable> {
+        self.vars.get_mut(i)
+    }
+
+    /// Adds a new rule to the program after normalizing it.
     pub fn add_rule(&mut self, rule: Rule) {
+        let rule = self.normalize_rule(rule);
+
         let steps = rule.decompose(|arity| self.new_predicate(arity));
         for step in steps {
             self.add_rule_step(step);
@@ -34,6 +54,75 @@ impl Program {
 
     fn add_rule_step(&mut self, rule: Box<dyn RuleStep>) {
         self.rules.push(rule);
+    }
+
+    /// Returns a new rule without symbols (constants) in the head (required by the internal rule representation)
+    /// after potentially adding new predicates and facts.
+    ///
+    /// More precisely, works by taking symbols (constants) in the head and "promoting" them to the body:
+    /// each symbol `Arg::Sym(c)` in the head is replaced by a fresh variable `Arg::Var(v)`
+    /// and an atom `singleton_c(Arg::Var(v))` is appended to the body.
+    ///
+    /// `singleton_c` is a fresh arity-1 predicate that is interned (cached)
+    /// per distinct `Arg::Sym(c)` and seeded with the single fact `singleton_c(c)`.
+    ///
+    /// If `Arg::Sym(c)` is the `i`-th encountered constant in the head, then `v` is chosen to be
+    /// the `i`-th integer in descending order starting from the maximum allowable value for `v`.
+    /// (Remember that this value only matters locally to the rule, not globally in the program)
+    fn normalize_rule(&mut self, rule: Rule) -> Rule {
+        #[cfg(debug_assertions)]
+        {
+            let max_rulelocal_var = rule
+                .head
+                .args()
+                .chain(rule.body.iter().flat_map(|a| a.args()))
+                .filter_map(|a| match a {
+                    Arg::Var(v) => Some(v),
+                    _ => None,
+                })
+                .max()
+                .unwrap_or(0);
+            let num_to_promote = rule.head.args().filter(|a| matches!(a, Arg::Sym(_))).count() as u32;
+            assert!(
+                max_rulelocal_var + num_to_promote < i32::MAX as u32,
+                "there are not enough fresh (local) var ids to promote symbols to ({max_rulelocal_var:?}, {num_to_promote:?})"
+            );
+        }
+
+        let mut fresh = (i32::MAX - 1) as u32;
+        let mut extra_body = Vec::new();
+        let rewritten_args: Vec<Arg> = rule
+            .head
+            .args()
+            .map(|arg| match arg {
+                Arg::Sym(c) => {
+                    let cached_symbol_predicate = if let Some(&i) = self.symbol_predicates_cache.get(&c) {
+                        assert!(self.vars[i].arity() == 1, "cached singleton predicate has non-1 arity");
+                        self.get_predicate(i).unwrap()
+                    } else {
+                        let i = self.num_predicates();
+                        let res = self.new_predicate(1);
+                        self.symbol_predicates_cache.insert(c, i);
+                        res.add([c]);
+                        self.get_predicate(i).unwrap()
+                    };
+                    let id = fresh;
+                    fresh = fresh.checked_sub(1).expect("fresh-id underflow");
+                    extra_body.push(cached_symbol_predicate.apply([Arg::Var(id)]));
+                    Arg::Var(id)
+                }
+                v @ Arg::Var(_) => v,
+            })
+            .collect();
+
+        let new_head = rule.head.predicate().apply(rewritten_args);
+        let new_body = {
+            let mut res = rule.body;
+            res.append(&mut extra_body);
+            res
+        };
+
+        Rule::new(new_head, new_body)
     }
 
     /// Returns true if the program is stable (i.e. inference has reached a fixed-point).

--- a/utils/datalog/src/rules.rs
+++ b/utils/datalog/src/rules.rs
@@ -319,10 +319,10 @@ impl Pattern {
         (term < 0).then(|| (-term - 1) as u32)
     }
     fn from_var(var: u32) -> i32 {
-        -(var as i32) - 1
+        -i32::try_from(var).unwrap() - 1
     }
     fn from_cst(cst: u32) -> i32 {
-        cst as i32
+        i32::try_from(cst).unwrap()
     }
 
     pub(crate) fn vars(&self) -> impl Iterator<Item = u32> + '_ {

--- a/utils/datalog/src/rules.rs
+++ b/utils/datalog/src/rules.rs
@@ -27,13 +27,22 @@ impl RuleAtom {
         assert_eq!(predicate.arity(), args.arity());
         Self { predicate, args }
     }
+
+    /// Returns a reference to the table of the atom's predicate.
+    pub fn predicate(&self) -> &VarTable {
+        &self.predicate
+    }
+
+    pub(crate) fn args(&self) -> impl Iterator<Item = Arg> {
+        self.args.as_args()
+    }
 }
 
 /// A rule in a datalog program, e.g. `ancestor(?x, ?z) :- parent(?x, ?y), ancestor(?y, ?z)`.
 #[derive(Clone)]
 pub struct Rule {
-    head: RuleAtom,
-    body: Vec<RuleAtom>,
+    pub(crate) head: RuleAtom,
+    pub(crate) body: Vec<RuleAtom>,
 }
 
 impl Rule {
@@ -325,6 +334,11 @@ impl Pattern {
                 *i = Self::from_var(f(var))
             }
         }
+    }
+    pub(crate) fn as_args(&self) -> impl Iterator<Item = Arg> {
+        self.pattern
+            .iter()
+            .map(|&i| Self::as_var(i).map_or(Arg::Sym(i as u32), Arg::Var))
     }
 
     /// Creates a new pattern where some variables are bound to a constant value.

--- a/utils/datalog/src/rules.rs
+++ b/utils/datalog/src/rules.rs
@@ -48,6 +48,23 @@ pub struct Rule {
 impl Rule {
     /// Creates an new rule from an head (single atom left of `:-`) and a body (conjunction of atoms on the right-side)
     pub fn new(head: RuleAtom, body: impl AsRef<[RuleAtom]>) -> Self {
+        #[cfg(debug_assertions)]
+        {
+            let head_vars = HashSet::<u32>::from_iter(head.args().filter_map(|a| match a {
+                Arg::Var(v) => Some(v),
+                _ => None,
+            }));
+            let body_vars =
+                HashSet::<u32>::from_iter(body.as_ref().iter().flat_map(|a| a.args()).filter_map(|a| match a {
+                    Arg::Var(v) => Some(v),
+                    _ => None,
+                }));
+            assert!(
+                head_vars.is_subset(&body_vars),
+                "rule is unsafe: a head variable does not appear in any body atom ({head_vars:?} {body_vars:?})"
+            );
+        }
+
         Self {
             head,
             body: body.as_ref().iter().cloned().collect_vec(),


### PR DESCRIPTION
This PR adds automatic normalization of symbols in rule heads, on addition to the datalog program.

Head symbols are replaced with fresh variables and singleton atoms appended to the body, enabling rules like `p(1, ?x) :- q(?x)` to work correctly. The predicates for these singleton atoms are cached per distinct symbol for reuse across rules.