### PR TITLE
doc(timelines): add initial timelines example usage

### DIFF
--- a/planning/timelines/examples/routing.rs
+++ b/planning/timelines/examples/routing.rs
@@ -1,0 +1,217 @@
+#![allow(unused)]
+
+use std::iter;
+
+use aries_solver::prelude::*;
+use aries_solver::{core::state::Evaluable, lang::ModelView};
+use aries_timelines::explain::ExplainableSolver;
+use aries_timelines::{constraints::HasValueAt, symbols::ObjectEncoding, *};
+use itertools::Itertools;
+
+struct Problem {
+    /// number of trucks available
+    num_trucks: usize,
+    /// Location to be visited by at least one truck
+    visits: Vec<Loc>,
+    /// initial and final location of all truck
+    depot: Loc,
+}
+
+impl Problem {
+    /// First and last location (used as bounds on the variables)
+    fn locations(&self) -> (Loc, Loc) {
+        (
+            *self.visits.iter().chain(iter::once(&self.depot)).min().unwrap(),
+            *self.visits.iter().chain(iter::once(&self.depot)).max().unwrap(),
+        )
+    }
+    /// First and last trucks (used as bounds on variables)
+    fn trucks(&self) -> (IntCst, IntCst) {
+        assert!(self.num_trucks > 0);
+        (1, self.num_trucks as IntCst)
+    }
+}
+
+/// A location is encoded as an integer constant
+type Loc = IntCst;
+
+fn solve_routing(pb: &Problem) -> Option<Vec<Op>> {
+    let objects = ObjectEncoding::empty();
+    let mut model = aries_timelines::Sched::new(1, objects);
+
+    let (first_truck, last_truck) = pb.trucks();
+
+    let mut actions = Vec::new();
+
+    for t in first_truck..=last_truck {
+        // Initial state (at origin):
+        // at the temporal origin, the truck is at the depot
+        let mutex_end = model.new_timepoint();
+        model.add_effect(Effect {
+            transition_start: model.origin, // at origin
+            transition_end: model.origin,
+            mutex_end,
+            state_var: truck_loc(t),                      // the location of this truck
+            operation: EffectOp::Assign(pb.depot.into()), // takes the value `depot`
+            prez: Lit::TRUE,
+            source: None,
+        });
+
+        // Goal state (at horizon):
+        // the truck must be at the depot
+        // Placing a condition like this forces the solver to find an effect that establishes th required value
+        model.add_constraint(HasValueAt {
+            state_var: truck_loc(t),  // the state variable denoting the location of this truck
+            value: pb.depot.into(),   // must have the value `depot`
+            timepoint: model.horizon, // at the end of the plan
+            prez: Lit::TRUE,          // this must always be true
+            source: None,             // not tied to any task
+        });
+
+        // each truck has an action that allows returning to the depot
+        // This action is optional (and indeed not needed if the truck never leaves the depot)
+        actions.push(add_move_to_action(Some(t), pb.depot, &mut model, pb))
+    }
+
+    for &loc in &pb.visits {
+        // for each place to visit, add an action where a truck (unspecified which one) can go there
+        let visit_loc_action = add_move_to_action(None, loc, &mut model, pb);
+
+        // in a TSP like problem, the visit is mandatory, so we force this action to be present
+        model.add_constraint(visit_loc_action.presence);
+        actions.push(visit_loc_action);
+    }
+    let mut solver: ExplainableSolver<()> = aries_timelines::explain::ExplainableSolver::new(&model, |_| None);
+    if let Some(solution) = solver.find_optimal(model.makespan.into(), |_| {}, vec![]) {
+        let mut operations: Vec<Op> = actions.iter().filter_map(|act| act.evaluate(&solution)).collect_vec();
+        operations.sort_by_key(|op| (op.truck, op.start));
+        Some(operations)
+    } else {
+        // no plan found
+        None
+    }
+}
+
+/// Returns the state variable representing the location of a truck
+fn truck_loc(truck: impl Into<LinTerm>) -> StateVar {
+    StateVar {
+        fluent: "loc".to_string(),
+        args: vec![truck.into()],
+    }
+}
+
+/// Adds an action that allows moving either a specific truck or any truck from its current location to a specified location
+fn add_move_to_action(truck: Option<IntCst>, to: IntCst, model: &mut Sched, pb: &Problem) -> MoveTo {
+    // literal encoding whether the action is present in the solution
+    let presence = model.new_bool_var();
+
+    // variables encoding the start and end time of the action
+    let start: VarCst = model.new_opt_timepoint(presence);
+    let end: VarCst = start + 1; // assumes a duration of 1
+
+    // records a new task for this action
+    // The tasks is necessary to determine things like the makespan of the plan (max end time of all present tasks)
+    // We use the returned task id to attach the conditions and effect to it.
+    let task_id = model.add_task(Task {
+        name: "move".to_string(),
+        start,
+        end,
+        presence,
+    });
+
+    // variable denoting which truck is moved by this action
+    let (first_truck, last_truck) = pb.trucks();
+    let truck: VarCst = if let Some(truck) = truck {
+        truck.into() // a specific truck is specified for this action
+    } else {
+        // no truck specified, make it a parameter by creating a variable
+        model.new_optional_var(first_truck, last_truck, presence).into()
+    };
+
+    // create a variable capturing the initial location of the truck
+    let (first_loc, last_loc) = pb.locations();
+    let from = model.new_optional_var(first_loc, last_loc, presence);
+
+    // effect that updates the truck location
+    // [start, end] loc(truck) <- to
+    let mutex_end = model.new_opt_timepoint(presence);
+    model.add_effect(Effect {
+        transition_start: start,     // the state variable looses its previous value at the action start
+        transition_end: end,         // and is assigned its new value at the action end
+        mutex_end,                   //
+        state_var: truck_loc(truck), // modifies the location of the truck
+        operation: EffectOp::Assign(to.into()), // assign it the destination `to`
+        prez: presence,              // effect is only present when the action is
+        source: Some(task_id),       // effect is introduced by this action
+    });
+
+    // condition that binds the truck location at the action start
+    // [start] loc(truck) == from
+    model.add_constraint(HasValueAt {
+        state_var: truck_loc(truck), // state variable denoting the location of the truck
+        value: from.into(),          // must have the value `from` (action parameter)
+        timepoint: start,            // at the action start
+        prez: presence,              // only needs to hold when the action is present
+        source: Some(task_id),       // condition introduced as part of the current action
+    });
+
+    // returns a representation of the action, to allow accessing its parameters
+    // and reconstruct it in the solution
+    MoveTo {
+        presence,
+        start,
+        truck,
+        from,
+        to,
+        task_id,
+    }
+}
+
+struct MoveTo {
+    presence: Lit,
+    start: VarCst,
+    truck: VarCst,
+    from: Var,
+    to: IntCst,
+    task_id: TaskId,
+}
+
+impl Evaluable for MoveTo {
+    type Value = Op;
+
+    fn evaluate(&self, solution: &Solution) -> Option<Self::Value> {
+        if !solution.entails(self.presence) {
+            // action is absent
+            return None;
+        }
+        Some(Op {
+            start: solution.eval(self.start).unwrap(),
+            truck: solution.eval(self.truck).unwrap(),
+            op: format!("move({}, {})", solution.eval(self.from).unwrap(), self.to),
+        })
+    }
+}
+
+/// Represents an actual operation in the plan
+#[derive(Debug)]
+struct Op {
+    start: IntCst,
+    truck: IntCst,
+    op: String,
+}
+
+fn main() {
+    let plan = solve_routing(&Problem {
+        num_trucks: 2,
+        visits: vec![1, 2, 3],
+        depot: 0,
+    });
+    if let Some(plan) = plan {
+        println!("Found plan:");
+        for op in plan {
+            println!(" - {op:?}");
+        }
+    } else {
+        println!("No plan...")
+    }
+}

--- a/planning/timelines/src/effects.rs
+++ b/planning/timelines/src/effects.rs
@@ -19,9 +19,10 @@ use crate::{
 pub struct Effect {
     /// Time at which the transition to the new value will start
     pub transition_start: Time,
-    /// Time at which the transition will end
+    /// Time at which the transition will end and the value is established.
     pub transition_end: Time,
-    /// If specified, the assign effect is required to persist at least until all of these timepoints.
+    /// Time until which the effect may persist.
+    /// In most cases, it should be be left as a free variable with the same scope as the effect.
     pub mutex_end: Time,
     /// State variable affected by the effect
     pub state_var: StateVar,

--- a/planning/timelines/src/lib.rs
+++ b/planning/timelines/src/lib.rs
@@ -168,14 +168,19 @@ impl Sched {
             println!("{}: {}", t.name, sol.eval(t.start).unwrap())
         }
         println!("==== Effects ====");
+        let mut formatted_effects: Vec<String> = vec![];
         for e in self.effects.iter().sorted_by_key(|e| &e.state_var.fluent) {
             if !sol.entails(e.prez) {
-                println!("{:?}", e);
                 continue;
             }
-            println!(
-                "{}: [{},{}] {} ...[{}]",
+            formatted_effects.push(format!(
+                "{}({}): [{},{}] {} ...[{}]",
                 e.state_var.fluent,
+                e.state_var
+                    .args
+                    .iter()
+                    .map(|arg| arg.evaluate(sol).unwrap())
+                    .format(", "),
                 e.transition_start.evaluate(sol).unwrap(),
                 e.transition_end.evaluate(sol).unwrap(),
                 match e.operation {
@@ -183,8 +188,10 @@ impl Sched {
                     EffectOp::Step(v) => format!("+= {}", v.evaluate(sol).unwrap()),
                 },
                 e.mutex_end.evaluate(sol).unwrap(),
-            );
+            ));
         }
+        formatted_effects.sort();
+        println!("{}", formatted_effects.iter().format("\n"));
         println!("Horizon: {}", self.horizon.evaluate(sol).unwrap())
     }
 }
@@ -196,5 +203,17 @@ impl Dom for Sched {
 
     fn _presence(&self, var: Var) -> Lit {
         self.model._presence(var)
+    }
+}
+
+impl ModelWrapper for Sched {
+    type Lbl = Sym;
+
+    fn get_model(&self) -> &aries_solver::model::Model<Self::Lbl> {
+        &self.model
+    }
+
+    fn get_model_mut(&mut self) -> &mut aries_solver::model::Model<Self::Lbl> {
+        &mut self.model
     }
 }

--- a/planning/timelines/src/symbols.rs
+++ b/planning/timelines/src/symbols.rs
@@ -24,6 +24,12 @@ pub struct ObjectEncoding {
 }
 
 impl ObjectEncoding {
+    pub fn empty() -> Self {
+        Self {
+            types: Default::default(),
+            objects: Default::default(),
+        }
+    }
     pub fn domain_of_type<Q>(&self, key: &Q) -> Option<Range>
     where
         Sym: Borrow<Q> + Ord,


### PR DESCRIPTION
@SachaPiat This provides an example for the usage of `aries-timelines`.

There are certainly many things to improve in the API but it should provide an initial reference for its usage.