### PR TITLE
ci: upgrade used python version to 3.12

### DIFF
--- a/.github/workflows/aries.yml
+++ b/.github/workflows/aries.yml
@@ -68,10 +68,10 @@ jobs:
           path: aries
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      - name: Install Python 3.10
+      - name: Install Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Minizinc
         run: |
           sudo snap install minizinc --classic --revision 1222
@@ -228,9 +228,9 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
       - name: Set Environment Variables
         run: |
           if [ "${{ matrix.os }}" == "ubuntu-latest" ] && [ "${{ matrix.target }}" == "amd64" ]; then
@@ -325,7 +325,7 @@ jobs:
           git describe --tags --match v[0-9]*
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
       - name: Install build tools
         run: pip install build
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
We were still using python 3.8 for some tasks which is outdated and resulted in CI fails