### PR TITLE
feat(solver): allow plugging external reasoners

### DIFF
--- a/examples/scheduling/src/search.rs
+++ b/examples/scheduling/src/search.rs
@@ -82,7 +82,7 @@ pub fn get_solver(mut base_solver: Solver, strategy: &SearchStrategy, pb: &Encod
                 "focused" => mode = Mode::Focused,
                 x if x.starts_with("+lbd") => {
                     let lvl = x.strip_prefix("+lbd").unwrap().parse().unwrap();
-                    base_solver.reasoners.sat.clauses.params.locked_lbd_level = lvl;
+                    base_solver.reasoners.sat().clauses.params.locked_lbd_level = lvl;
                 }
                 "" => {} // ignore
                 _ => panic!("Unsupported option: {opt}"),

--- a/planning/planners/src/solver.rs
+++ b/planning/planners/src/solver.rs
@@ -381,7 +381,7 @@ pub fn init_solver(model: Model<VarLabel>) -> Box<Solver> {
     };
 
     let mut solver = Box::new(aries_solver::solver::Solver::new(model));
-    solver.reasoners.diff.config = stn_config;
+    solver.reasoners.diff().config = stn_config;
     solver
 }
 
@@ -446,11 +446,11 @@ impl Strat {
             }
             Strat::ActivityBoolLight => {
                 solver.set_brancher(ActivityBrancher::new_with_heuristic(ActivityBoolFirstHeuristic));
-                solver.reasoners.diff.config.theory_propagation = TheoryPropagationLevel::Bounds;
+                solver.reasoners.diff().config.theory_propagation = TheoryPropagationLevel::Bounds;
             }
             Strat::Forward => {
                 solver.set_brancher(ForwardSearcher::new(problem));
-                solver.reasoners.diff.config.theory_propagation = TheoryPropagationLevel::Bounds;
+                solver.reasoners.diff().config.theory_propagation = TheoryPropagationLevel::Bounds;
             }
             Strat::Causal => {
                 let strat = causal_brancher(problem, encoding);

--- a/solver/src/reasoners/mod.rs
+++ b/solver/src/reasoners/mod.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools;
+
 use crate::backtrack::Backtrack;
 use crate::core::Lit;
 use crate::core::state::{Cause, DomainsSnapshot, Explainer, InferenceCause};
@@ -21,6 +23,7 @@ pub enum ReasonerId {
     Diff,
     Cp,
     Tautologies,
+    Extra(u8),
 }
 
 impl ReasonerId {
@@ -32,6 +35,7 @@ impl ReasonerId {
 impl Display for ReasonerId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use ReasonerId::*;
+        let mut _extra_str = String::new();
         write!(
             f,
             "{}",
@@ -40,12 +44,16 @@ impl Display for ReasonerId {
                 Diff => "DiffLog",
                 Cp => "CP",
                 Tautologies => "Optim",
+                Extra(i) => {
+                    _extra_str = format!("Extra({i})");
+                    &_extra_str
+                }
             }
         )
     }
 }
 
-pub trait Theory: Backtrack + Send + 'static {
+pub trait Theory: Backtrack + Send {
     fn identity(&self) -> ReasonerId;
 
     fn propagate(&mut self, model: &mut Domains) -> Result<(), Contradiction>;
@@ -90,48 +98,140 @@ pub(crate) const REASONERS: [ReasonerId; 4] = [
     ReasonerId::Cp,
 ];
 
-/// A set of inference modules for constraint propagation.
-#[derive(Clone)]
-pub struct Reasoners {
+pub(crate) struct ReasonersTheories {
     pub sat: SatSolver,
     pub diff: StnTheory,
-    pub(crate) cp: Cp,
-    pub(crate) tautologies: Tautologies,
+    pub cp: Cp,
+    pub tautologies: Tautologies,
+    pub extra: Vec<Box<dyn Theory>>,
 }
-impl Reasoners {
+impl Clone for ReasonersTheories {
+    fn clone(&self) -> Self {
+        Self {
+            sat: self.sat.clone(),
+            diff: self.diff.clone(),
+            cp: self.cp.clone(),
+            tautologies: self.tautologies.clone(),
+            extra: self.extra.iter().map(|th| th.clone_box()).collect(),
+        }
+    }
+}
+impl ReasonersTheories {
     pub fn new() -> Self {
-        Reasoners {
+        ReasonersTheories {
             sat: SatSolver::new(ReasonerId::Sat),
             diff: StnTheory::new(Default::default()),
             cp: Cp::new(ReasonerId::Cp),
             tautologies: Tautologies::default(),
+            extra: vec![],
         }
     }
+    pub fn with_extra(extra: Vec<Box<dyn Theory>>) -> Self {
+        assert!(
+            extra
+                .iter()
+                .map(|r| r.identity())
+                .all(|rid| matches!(rid, ReasonerId::Extra(_)))
+        );
+        assert!(extra.iter().map(|r| r.identity()).all_unique());
 
-    pub fn reasoner(&self, id: ReasonerId) -> &dyn Theory {
+        ReasonersTheories {
+            sat: SatSolver::new(ReasonerId::Sat),
+            diff: StnTheory::new(Default::default()),
+            cp: Cp::new(ReasonerId::Cp),
+            tautologies: Tautologies::default(),
+            extra,
+        }
+    }
+    pub fn get(&self, id: ReasonerId) -> &dyn Theory {
         match id {
             ReasonerId::Sat => &self.sat,
             ReasonerId::Diff => &self.diff,
             ReasonerId::Cp => &self.cp,
             ReasonerId::Tautologies => &self.tautologies,
+            ReasonerId::Extra(id) => self.extra.get(id as usize).unwrap().as_ref(),
         }
     }
-
-    pub fn reasoner_mut(&mut self, id: ReasonerId) -> &mut dyn Theory {
+    pub fn get_mut(&mut self, id: ReasonerId) -> &mut dyn Theory {
         match id {
             ReasonerId::Sat => &mut self.sat,
             ReasonerId::Diff => &mut self.diff,
             ReasonerId::Cp => &mut self.cp,
             ReasonerId::Tautologies => &mut self.tautologies,
+            ReasonerId::Extra(id) => self.extra.get_mut(id as usize).unwrap().as_mut(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ReasonersWriters {
+    writers: Vec<ReasonerId>,
+}
+impl ReasonersWriters {
+    pub fn new() -> Self {
+        Self {
+            writers: REASONERS.to_vec(),
+        }
+    }
+    pub fn with_extra(extra: &Vec<Box<dyn Theory>>) -> Self {
+        assert!(
+            extra
+                .iter()
+                .map(|r| r.identity())
+                .all(|rid| matches!(rid, ReasonerId::Extra(_)))
+        );
+        assert!(extra.iter().map(|r| r.identity()).all_unique());
+
+        Self {
+            writers: REASONERS
+                .into_iter()
+                .chain(extra.iter().map(|r| r.identity()))
+                .collect(),
+        }
+    }
+    pub fn get(&self) -> &[ReasonerId] {
+        &self.writers
+    }
+}
+
+/// A set of inference modules for constraint propagation.
+#[derive(Clone)]
+pub struct Reasoners {
+    pub(crate) writers: ReasonersWriters,
+    pub(crate) theories: ReasonersTheories,
+}
+impl Reasoners {
+    pub fn new() -> Self {
+        Self {
+            writers: ReasonersWriters::new(),
+            theories: ReasonersTheories::new(),
+        }
+    }
+    pub fn with_extra(extra: Vec<Box<dyn Theory>>) -> Self {
+        Self {
+            writers: ReasonersWriters::with_extra(&extra),
+            theories: ReasonersTheories::with_extra(extra),
         }
     }
 
-    pub fn writers(&self) -> &'static [ReasonerId] {
-        &REASONERS
+    pub fn sat(&mut self) -> &mut SatSolver {
+        &mut self.theories.sat
+    }
+    pub fn diff(&mut self) -> &mut StnTheory {
+        &mut self.theories.diff
+    }
+    pub fn cp(&mut self) -> &mut Cp {
+        &mut self.theories.cp
+    }
+    pub fn tautologies(&mut self) -> &mut Tautologies {
+        &mut self.theories.tautologies
+    }
+    pub fn extra(&mut self) -> &mut [Box<dyn Theory>] {
+        &mut self.theories.extra
     }
 
-    pub fn theories(&self) -> impl Iterator<Item = (ReasonerId, &dyn Theory)> + '_ {
-        self.writers().iter().map(|w| (*w, self.reasoner(*w)))
+    pub fn iter(&self) -> impl Iterator<Item = (ReasonerId, &dyn Theory)> + '_ {
+        self.writers.get().iter().map(|w| (*w, self.theories.get(*w)))
     }
 }
 
@@ -143,7 +243,8 @@ impl Default for Reasoners {
 
 impl Explainer for Reasoners {
     fn explain(&mut self, cause: InferenceCause, literal: Lit, model: &DomainsSnapshot, explanation: &mut Explanation) {
-        self.reasoner_mut(cause.writer)
+        self.theories
+            .get_mut(cause.writer)
             .explain(literal, cause, model, explanation)
     }
 }

--- a/solver/src/reasoners/mod.rs
+++ b/solver/src/reasoners/mod.rs
@@ -103,7 +103,7 @@ pub(crate) struct ReasonersTheories {
     pub diff: StnTheory,
     pub cp: Cp,
     pub tautologies: Tautologies,
-    pub extra: Vec<Box<dyn Theory>>,
+    pub extra: Vec<Option<Box<dyn Theory>>>,
 }
 impl Clone for ReasonersTheories {
     fn clone(&self) -> Self {
@@ -112,7 +112,11 @@ impl Clone for ReasonersTheories {
             diff: self.diff.clone(),
             cp: self.cp.clone(),
             tautologies: self.tautologies.clone(),
-            extra: self.extra.iter().map(|th| th.clone_box()).collect(),
+            extra: self
+                .extra
+                .iter()
+                .map(|th| th.as_ref().map(|th| th.clone_box()))
+                .collect(),
         }
     }
 }
@@ -135,6 +139,21 @@ impl ReasonersTheories {
         );
         assert!(extra.iter().map(|r| r.identity()).all_unique());
 
+        let extra = {
+            let mut res = vec![];
+            for r in extra {
+                let ReasonerId::Extra(i) = r.identity() else {
+                    unreachable!()
+                };
+                let i = i as usize;
+                while res.len() <= i {
+                    res.push(None);
+                }
+                res[i] = Some(r);
+            }
+            res
+        };
+
         ReasonersTheories {
             sat: SatSolver::new(ReasonerId::Sat),
             diff: StnTheory::new(Default::default()),
@@ -149,7 +168,7 @@ impl ReasonersTheories {
             ReasonerId::Diff => &self.diff,
             ReasonerId::Cp => &self.cp,
             ReasonerId::Tautologies => &self.tautologies,
-            ReasonerId::Extra(id) => self.extra.get(id as usize).unwrap().as_ref(),
+            ReasonerId::Extra(id) => self.extra.get(id as usize).unwrap().as_ref().unwrap().as_ref(),
         }
     }
     pub fn get_mut(&mut self, id: ReasonerId) -> &mut dyn Theory {
@@ -158,7 +177,7 @@ impl ReasonersTheories {
             ReasonerId::Diff => &mut self.diff,
             ReasonerId::Cp => &mut self.cp,
             ReasonerId::Tautologies => &mut self.tautologies,
-            ReasonerId::Extra(id) => self.extra.get_mut(id as usize).unwrap().as_mut(),
+            ReasonerId::Extra(id) => self.extra.get_mut(id as usize).unwrap().as_mut().unwrap().as_mut(),
         }
     }
 }
@@ -173,7 +192,7 @@ impl ReasonersWriters {
             writers: REASONERS.to_vec(),
         }
     }
-    pub fn with_extra(extra: &Vec<Box<dyn Theory>>) -> Self {
+    pub fn with_extra(extra: &[Box<dyn Theory>]) -> Self {
         assert!(
             extra
                 .iter()
@@ -226,8 +245,8 @@ impl Reasoners {
     pub fn tautologies(&mut self) -> &mut Tautologies {
         &mut self.theories.tautologies
     }
-    pub fn extra(&mut self) -> &mut [Box<dyn Theory>] {
-        &mut self.theories.extra
+    pub fn extra(&mut self) -> impl Iterator<Item = &mut Box<dyn Theory>> + '_ {
+        self.theories.extra.iter_mut().filter_map(|th| th.as_mut())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (ReasonerId, &dyn Theory)> + '_ {

--- a/solver/src/solver/solver_impl.rs
+++ b/solver/src/solver/solver_impl.rs
@@ -124,14 +124,24 @@ pub struct Solver<Lbl> {
 }
 impl<Lbl: Label> Solver<Lbl> {
     pub fn new(model: Model<Lbl>) -> Solver<Lbl> {
+        Self::with_extra_reasoners(model, vec![])
+    }
+
+    pub fn with_extra_reasoners(
+        model: Model<Lbl>,
+        extra_reasoners: Vec<Box<dyn crate::reasoners::Theory>>,
+    ) -> Solver<Lbl> {
+        let reasoners = Reasoners::with_extra(extra_reasoners);
+        let stats = Stats::with_reasoners(&reasoners);
+
         Solver {
             model,
             next_unposted_constraint: 0,
             brancher: default_brancher(),
-            reasoners: Reasoners::new(),
+            reasoners,
             decision_level: DecLvl::ROOT,
             last_assumption_level: DecLvl::ROOT,
-            stats: Default::default(),
+            stats,
             sync: Synchro::new(),
         }
     }
@@ -192,7 +202,7 @@ impl<Lbl: Label> Solver<Lbl> {
             Constraint::Propagator(user_propagator) => {
                 // black-box propagator, there is nothing we can do except posting it to the CP solver
                 for prop in user_propagator.get_propagators() {
-                    self.reasoners.cp.add_propagator(prop);
+                    self.reasoners.cp().add_propagator(prop);
                 }
                 return Ok(());
             }
@@ -261,7 +271,7 @@ impl<Lbl: Label> Solver<Lbl> {
                         debug_assert!(factor > 0);
                         // cst + factor *(b - a) <= 0
                         // (b - a) <= -cst / factor
-                        self.reasoners.diff.add_half_reified_edge(
+                        self.reasoners.diff().add_half_reified_edge(
                             enabler,
                             a,
                             b,
@@ -311,7 +321,9 @@ impl<Lbl: Label> Solver<Lbl> {
                         };
                         // add a dynamic edge to the STN, specifying that `tgt -src <= ub_var * ub_factor`
                         // Each time a new upper bound is inferred on `ub_var` a new edge will temporarily added.
-                        self.reasoners.diff.add_dynamic_edge(src, tgt, ub_var, ub_factor, doms)
+                        self.reasoners
+                            .diff()
+                            .add_dynamic_edge(src, tgt, ub_var, ub_factor, doms)
                     }
                     None // we posted redendant constraint, but this is not an exact reformulation, we need to post the original one as well
                 } else {
@@ -321,7 +333,7 @@ impl<Lbl: Label> Solver<Lbl> {
                     self.post_constraint(&Constraint::HalfReified(reformulated, enabler))
                 } else {
                     self.reasoners
-                        .cp
+                        .cp()
                         .add_half_reif_linear_leq_constraint(lin, enabler, &self.model.state);
                     Ok(())
                 }
@@ -350,7 +362,7 @@ impl<Lbl: Label> Solver<Lbl> {
         if propagatable.is_empty() {
             return self.model.state.set(!scope, Cause::Encoding).map(|_| ());
         }
-        self.reasoners.sat.add_clause_scoped(propagatable.literals(), scope);
+        self.reasoners.sat().add_clause_scoped(propagatable.literals(), scope);
         Ok(())
     }
 
@@ -500,7 +512,7 @@ impl<Lbl: Label> Solver<Lbl> {
 
                     if let Some(dl) = self.backtrack_level_for_clause(&clause) {
                         self.restore(dl);
-                        self.reasoners.sat.add_clause(&clause);
+                        self.reasoners.sat().add_clause(&clause);
                     } else {
                         return Ok(sat);
                     }
@@ -656,7 +668,7 @@ impl<Lbl: Label> Solver<Lbl> {
                         return Err(Exit::Interrupted);
                     }
                     InputSignal::LearnedClause(cl) => {
-                        self.reasoners.sat.add_forgettable_clause(cl.literals());
+                        self.reasoners.sat().add_forgettable_clause(cl.literals());
                         requires_new_propagation = true;
                     }
                     InputSignal::SolutionFound(assignment) => {
@@ -1002,10 +1014,10 @@ impl<Lbl: Label> Solver<Lbl> {
                 // clauses with a single literal are tautologies and can be given to the dedicated reasoner
                 // note: a possible optimization would also be to not backjump to the root (always the case with a such clauses)
                 // but instead to the first level where imposing it would not result in a conflict
-                self.reasoners.tautologies.add_tautology(expl.clause.literals()[0])
+                self.reasoners.tautologies().add_tautology(expl.clause.literals()[0])
             } else {
                 // add clause to sat solver, making sure the asserted literal is set to true
-                self.reasoners.sat.add_learnt_clause(expl.clause.literals());
+                self.reasoners.sat().add_learnt_clause(expl.clause.literals());
             }
 
             true
@@ -1086,16 +1098,16 @@ impl<Lbl: Label> Solver<Lbl> {
             let num_events_at_start = self.model.state.num_events();
 
             debug_assert_eq!(
-                self.reasoners.writers().iter().next(),
+                self.reasoners.writers.get().iter().next(),
                 Some(&ReasonerId::Sat),
                 "SAT propagator should propagate first to ensure none of its invariant are violated by others."
             );
             // propagate all theories
-            for &i in self.reasoners.writers() {
+            for &i in self.reasoners.writers.get() {
                 let trail_size = self.model.state.trail().len() as u64;
                 let theory_propagation_start = StartCycleCount::now();
                 self.stats[i].propagation_loops += 1;
-                let th = self.reasoners.reasoner_mut(i);
+                let th = self.reasoners.theories.get_mut(i);
 
                 match th.propagate(&mut self.model.state) {
                     Ok(()) => (),
@@ -1141,7 +1153,7 @@ impl<Lbl: Label> Solver<Lbl> {
 
     pub fn print_stats(&self) {
         println!("{}", self.stats);
-        for (i, th) in self.reasoners.theories() {
+        for (i, th) in self.reasoners.iter() {
             println!("====== {i} =====");
             th.print_stats();
         }
@@ -1162,8 +1174,8 @@ impl<Lbl> Backtrack for Solver<Lbl> {
         assert_eq!(self.model.save_state(), n);
         assert_eq!(self.brancher.save_state(), n);
 
-        for w in self.reasoners.writers() {
-            let th = self.reasoners.reasoner_mut(*w);
+        for w in self.reasoners.writers.get() {
+            let th = self.reasoners.theories.get_mut(*w);
             assert_eq!(th.save_state(), n);
         }
         n
@@ -1174,7 +1186,7 @@ impl<Lbl> Backtrack for Solver<Lbl> {
             let n = self.decision_level.to_int();
             assert_eq!(self.model.num_saved(), n);
             assert_eq!(self.brancher.num_saved(), n);
-            for (_, th) in self.reasoners.theories() {
+            for (_, th) in self.reasoners.iter() {
                 assert_eq!(th.num_saved(), n);
             }
             true
@@ -1194,8 +1206,8 @@ impl<Lbl> Backtrack for Solver<Lbl> {
         }
         self.model.restore(saved_id);
         self.brancher.restore(saved_id);
-        for w in self.reasoners.writers() {
-            let th = self.reasoners.reasoner_mut(*w);
+        for w in self.reasoners.writers.get() {
+            let th = self.reasoners.theories.get_mut(*w);
             th.restore(saved_id);
         }
         debug_assert_eq!(self.current_decision_level(), saved_id);

--- a/solver/src/solver/stats.rs
+++ b/solver/src/solver/stats.rs
@@ -1,7 +1,6 @@
 use crate::backtrack::DecLvl;
 use crate::core::{IntCst, Lit};
-use crate::reasoners::REASONERS;
-use crate::reasoners::ReasonerId;
+use crate::reasoners::{ReasonerId, Reasoners};
 use crate::utils::cpu_time::*;
 use aries_env_param::EnvParam;
 use std::collections::BTreeMap;
@@ -39,9 +38,9 @@ pub struct ModuleStat {
 }
 
 impl Stats {
-    pub fn new() -> Stats {
+    pub fn with_reasoners(reasoners: &Reasoners) -> Stats {
         let mut per_mod = BTreeMap::new();
-        for id in &REASONERS {
+        for id in reasoners.writers.get() {
             per_mod.insert(*id, ModuleStat::default());
         }
 
@@ -107,12 +106,6 @@ impl Stats {
 
     pub fn num_conflicts(&self) -> u64 {
         self.num_conflicts
-    }
-}
-
-impl Default for Stats {
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
This PR changes the reasoners API to allow plugging in custom external reasoners on demand.

The verbosity of this new API is comes from the need to please the borrow checker in the loop over theories in `solver_impl.rs`.
Indeed, if I recall correctly (these commits are actually quite old), there were no issues with it before because `Theory` had a `static` lifetime.