### PR TITLE
feat(lprelax): add a first implementation of an LP relaxation reasoner based on HiGHS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aries-solver-lprelax"
+version = "0.1.0"
+dependencies = [
+ "aries-env-param",
+ "aries-solver",
+ "highs",
+ "itertools 0.14.0",
+ "smallvec",
+]
+
+[[package]]
 name = "aries-timelines"
 version = "0.1.0"
 dependencies = [
@@ -426,6 +437,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +517,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex 2.0.1",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +566,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -572,6 +633,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -877,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "gnuplot"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1158,24 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "highs"
+version = "2.1.0"
+source = "git+https://github.com/nrealus/highs.git#93f6d570511da2b1346118aeb13562ad1b5464e5"
+dependencies = [
+ "highs-sys",
+ "log",
+]
+
+[[package]]
+name = "highs-sys"
+version = "1.13.1"
+source = "git+https://github.com/nrealus/highs-sys.git#a7189b1e5943a2ee00d3a7be2be44e6c16247696"
+dependencies = [
+ "bindgen",
+ "cmake",
+]
 
 [[package]]
 name = "http"
@@ -1303,6 +1403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,6 +1533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1564,16 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2039,6 +2165,18 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "solver",
+    "solver/lprelax",
     "bench/data",
     "bench/bench",
     "utils/env_param",

--- a/solver/lprelax/Cargo.toml
+++ b/solver/lprelax/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "aries-solver-lprelax"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+aries-solver = { path = ".." }
+aries-env-param = { path = "../../utils/env_param" }
+highs = { git = "https://github.com/nrealus/highs.git" }
+itertools = { workspace = true }
+smallvec = { workspace = true }

--- a/solver/lprelax/src/bindings.rs
+++ b/solver/lprelax/src/bindings.rs
@@ -1,0 +1,95 @@
+use std::{collections::HashMap, sync::Arc};
+
+use aries_solver::prelude::{Lit, Var};
+use smallvec::{SmallVec, smallvec};
+
+use crate::{LpCol, LpLit};
+
+pub type LitToLpLitsBindingFn = dyn Fn(Lit) -> SmallVec<[LpLit; 4]> + Send + Sync;
+pub type LpLitToLitsBindingFn = dyn Fn(LpLit) -> SmallVec<[Lit; 4]> + Send + Sync;
+
+#[derive(Clone, Default)]
+pub(crate) struct LpRelaxBindings {
+    lit_to_lplits_bindings: HashMap<Var, LitToLpLitsBindings>,
+    lplit_to_lits_bindings: HashMap<LpCol, LpLitToLitsBindings>,
+}
+impl LpRelaxBindings {
+    pub fn add_lit_to_lplits_binding(&mut self, var: Var, func: Arc<LitToLpLitsBindingFn>) {
+        self.lit_to_lplits_bindings
+            .entry(var)
+            .or_insert_with(|| LitToLpLitsBindings::new(var))
+            .add(func);
+    }
+    pub fn add_lplit_to_lits_binding(&mut self, col: LpCol, func: Arc<LpLitToLitsBindingFn>) {
+        self.lplit_to_lits_bindings
+            .entry(col)
+            .or_insert_with(|| LpLitToLitsBindings::new(col))
+            .add(func);
+    }
+    pub fn add_lit_to_lplits_binding_default(&mut self, var: Var, col: LpCol) {
+        self.lit_to_lplits_bindings
+            .entry(var)
+            .or_insert_with(|| LitToLpLitsBindings::new(var))
+            .add_default(var, col);
+    }
+    pub fn add_lplit_to_lits_binding_default(&mut self, var: Var, col: LpCol) {
+        self.lplit_to_lits_bindings
+            .entry(col)
+            .or_insert_with(|| LpLitToLitsBindings::new(col))
+            .add_default(var, col);
+    }
+    pub fn compute_implied_lplits(&self, lit: Lit) -> Option<impl Iterator<Item = LpLit>> {
+        self.lit_to_lplits_bindings
+            .get(&lit.variable())
+            .map(|bindings| bindings.compute_implied_lplits(lit))
+    }
+    pub fn compute_implied_lits(&self, lplit: LpLit) -> Option<impl Iterator<Item = Lit>> {
+        self.lplit_to_lits_bindings
+            .get(&lplit.col)
+            .map(|bindings| bindings.compute_implied_lit(lplit))
+    }
+}
+
+#[derive(Clone)]
+struct LitToLpLitsBindings {
+    var: Var,
+    funcs: Vec<Arc<LitToLpLitsBindingFn>>,
+}
+impl LitToLpLitsBindings {
+    fn new(var: Var) -> Self {
+        Self { var, funcs: vec![] }
+    }
+    fn add_default(&mut self, var: Var, col: LpCol) {
+        assert!(var == self.var);
+        self.add(Arc::new(move |lit| smallvec![LpLit::from_model_lit(col, lit)]))
+    }
+    fn add(&mut self, func: Arc<LitToLpLitsBindingFn>) {
+        self.funcs.push(func);
+    }
+    fn compute_implied_lplits(&self, lit: Lit) -> impl Iterator<Item = LpLit> + use<'_> {
+        assert!(lit.variable() == self.var);
+        self.funcs.iter().flat_map(move |func| func(lit))
+    }
+}
+
+#[derive(Clone)]
+struct LpLitToLitsBindings {
+    col: LpCol,
+    funcs: Vec<Arc<LpLitToLitsBindingFn>>,
+}
+impl LpLitToLitsBindings {
+    fn new(col: LpCol) -> Self {
+        Self { col, funcs: vec![] }
+    }
+    fn add_default(&mut self, var: Var, col: LpCol) {
+        assert!(col == self.col);
+        self.add(Arc::new(move |lplit| smallvec![lplit.into_model_lit(var)]))
+    }
+    fn add(&mut self, func: Arc<LpLitToLitsBindingFn>) {
+        self.funcs.push(func);
+    }
+    fn compute_implied_lit(&self, lplit: LpLit) -> impl Iterator<Item = Lit> + use<'_> {
+        assert!(lplit.col == self.col);
+        self.funcs.iter().flat_map(move |func| func(lplit))
+    }
+}

--- a/solver/lprelax/src/lib.rs
+++ b/solver/lprelax/src/lib.rs
@@ -1,0 +1,900 @@
+mod bindings;
+mod lplit;
+mod types;
+
+use aries_solver::backtrack::{Backtrack, DecLvl, EventIndex, ObsTrailCursor, Trail};
+use aries_solver::core::literals::ConjunctionBuilder;
+use aries_solver::core::state::{DomainsSnapshot, Explanation, InferenceCause};
+use aries_solver::prelude::*;
+use aries_solver::reasoners::{Contradiction, ReasonerId, Theory};
+
+use bindings::LpRelaxBindings;
+pub use bindings::{LitToLpLitsBindingFn, LpLitToLitsBindingFn};
+pub use lplit::*;
+pub use types::*;
+
+#[derive(Debug, Clone)]
+struct LpEvent {
+    pub new_lplit: LpLit,
+    pub prev_lplit: LpLit,
+    pub cause: LpEventCause,
+}
+impl LpEvent {
+    pub fn new(new_lplit: LpLit, prev_lplit: LpLit, cause: LpEventCause) -> Self {
+        Self {
+            new_lplit,
+            prev_lplit,
+            cause,
+        }
+    }
+}
+#[derive(Debug, Clone)]
+enum LpEventCause {
+    MainModel(Lit),
+    ReducedCostStrengthtening(Vec<LpLit>),
+}
+
+type ModelEvent = aries_solver::core::state::Event;
+
+#[derive(Copy, Clone)]
+struct ModelUpdateCause(EventIndex);
+
+impl From<u32> for ModelUpdateCause {
+    fn from(enc: u32) -> Self {
+        ModelUpdateCause(enc.into())
+    }
+}
+impl From<ModelUpdateCause> for u32 {
+    fn from(cause: ModelUpdateCause) -> Self {
+        cause.0.into()
+    }
+}
+
+#[derive(Default, Clone)]
+struct LpRelaxStats {
+    pub lpruns: u64,
+    pub lpruns_time: std::time::Duration,
+}
+
+#[derive(Clone)]
+pub struct LpRelaxConfig {
+    use_propagation_skips: bool,
+}
+impl Default for LpRelaxConfig {
+    fn default() -> Self {
+        Self {
+            use_propagation_skips: true,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LpRelaxObjective {
+    pub col: LpCol,
+    pub var: Var,
+    pub sense: LpObjectiveSense,
+}
+
+struct LpRelaxState {
+    model_events: ObsTrailCursor<ModelEvent>,
+    trail: Trail<LpEvent>,
+
+    lpmodel: LpModel,
+    lpobjective: Option<LpRelaxObjective>,
+}
+impl Clone for LpRelaxState {
+    fn clone(&self) -> Self {
+        let mut lpmodel = self.lpmodel.clone();
+        set_lpmodel_options(&mut lpmodel);
+
+        Self {
+            model_events: self.model_events.clone(),
+            trail: self.trail.clone(),
+            lpmodel,
+            lpobjective: self.lpobjective.clone(),
+        }
+    }
+}
+fn set_lpmodel_options(lpmodel: &mut LpModel) {
+    //lpmodel.set_option("time_limit", 2.0); // stop after 2 seconds
+    lpmodel.set_option("parallel", "off"); // use 1 core
+    lpmodel.set_option("threads", 1); // solve on 1 thread
+    lpmodel.set_option("iis_strategy", 0); // https://github.com/ERGO-Code/HiGHS/blob/3be639f037e0001b617c59830d3965f246ab5beb/highs/interfaces/highs_c_api.h#L153
+}
+impl Default for LpRelaxState {
+    fn default() -> Self {
+        let mut lpmodel = LpModel::default(LpObjectiveSense::Minimise);
+        set_lpmodel_options(&mut lpmodel);
+
+        Self {
+            model_events: ObsTrailCursor::default(),
+            trail: Trail::default(),
+            lpmodel,
+            lpobjective: None,
+        }
+    }
+}
+impl LpRelaxState {
+    fn num_rows(&self) -> usize {
+        self.lpmodel.num_rows()
+    }
+    fn num_columns(&self) -> usize {
+        self.lpmodel.num_columns()
+    }
+    #[allow(dead_code)]
+    fn columns(&self) -> Vec<LpCol> {
+        (0..self.lpmodel.num_columns()).map(LpCol::from).collect()
+    }
+
+    fn get_column_lower_bound(&self, col: LpCol) -> IntCst {
+        float_as_exact_int_cst(self.lpmodel.get_column_bounds(col).0)
+    }
+    fn get_column_upper_bound(&self, col: LpCol) -> IntCst {
+        float_as_exact_int_cst(self.lpmodel.get_column_bounds(col).1)
+    }
+    fn add_column(&mut self, lb: Option<FloatCst>, ub: Option<FloatCst>) -> LpCol {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+
+        let lb = lb.unwrap_or(FloatCst::MIN);
+        let ub = ub.unwrap_or(FloatCst::MAX);
+        assert!(lb <= ub);
+
+        self.lpmodel.add_column(0., lb..ub, []).unwrap()
+    }
+    fn add_columns(&mut self, lbs_ubs: &[(Option<FloatCst>, Option<FloatCst>)]) -> Vec<LpCol> {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+
+        let lbs_ubs = Vec::from_iter(
+            lbs_ubs
+                .iter()
+                .map(|(lb, ub)| (lb.unwrap_or(FloatCst::MIN), ub.unwrap_or(FloatCst::MAX))),
+        );
+        self.lpmodel.add_columns(&lbs_ubs).unwrap()
+    }
+    fn tighten_column(&mut self, col: LpCol, lb: Option<FloatCst>, ub: Option<FloatCst>) -> bool {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+        let mut res = false;
+
+        let old_lb = self.get_column_lower_bound(col);
+        let lb = if let Some(lb) = lb
+            && old_lb < float_as_exact_int_cst(lb)
+        {
+            res = true;
+            float_as_exact_int_cst(lb)
+        } else {
+            old_lb
+        };
+        let old_ub = self.get_column_upper_bound(col);
+        let ub = if let Some(ub) = ub
+            && float_as_exact_int_cst(ub) < old_ub
+        {
+            res = true;
+            float_as_exact_int_cst(ub)
+        } else {
+            old_ub
+        };
+        assert!(lb <= ub);
+
+        self.lpmodel.change_column_bounds(col, lb..ub);
+        res
+    }
+    fn change_column(&mut self, col: LpCol, lb: Option<FloatCst>, ub: Option<FloatCst>) {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+        let lb = if let Some(lb) = lb {
+            float_as_exact_int_cst(lb)
+        } else {
+            INT_CST_MIN
+        };
+        let ub = if let Some(ub) = ub {
+            float_as_exact_int_cst(ub)
+        } else {
+            INT_CST_MAX
+        };
+        assert!(lb <= ub);
+
+        self.lpmodel.change_column_bounds(col, lb..ub);
+    }
+    fn add_row(
+        &mut self,
+        row_coefs: impl Iterator<Item = (LpCol, FloatCst)>,
+        lb: Option<FloatCst>,
+        ub: Option<FloatCst>,
+    ) -> LpRow {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+
+        let lb = lb.unwrap_or(FloatCst::MIN);
+        let ub: f64 = ub.unwrap_or(FloatCst::MAX);
+        let num_columns = self.num_columns();
+        self.lpmodel
+            .add_row(
+                lb..ub,
+                row_coefs.inspect(|(col, _)| debug_assert!(col.index() < num_columns)),
+            )
+            .unwrap()
+    }
+    fn add_rows(
+        &mut self,
+        rows_coefs: &[Vec<(LpCol, FloatCst)>],
+        lbs_ubs: &[(Option<FloatCst>, Option<FloatCst>)],
+    ) -> Vec<LpRow> {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+        debug_assert!(
+            rows_coefs
+                .iter()
+                .all(|row_coefs| row_coefs.iter().all(|(col, _)| col.index() < self.num_columns()))
+        );
+
+        let lbs_ubs: Vec<_> = lbs_ubs
+            .iter()
+            .map(|(lb, ub)| (lb.unwrap_or(FloatCst::MIN), ub.unwrap_or(FloatCst::MAX)))
+            .collect();
+
+        self.lpmodel.add_rows(&lbs_ubs, rows_coefs).unwrap()
+    }
+
+    fn add_objective_column(
+        &mut self,
+        var: Var,
+        coefs: impl Iterator<Item = (LpCol, FloatCst)>,
+        sense: LpObjectiveSense,
+    ) -> LpCol {
+        assert!(self.trail.current_decision_level() == DecLvl::ROOT);
+        assert!(self.lpobjective.is_none());
+
+        self.lpobjective = Some(LpRelaxObjective {
+            col: self.add_column(None::<FloatCst>, None::<FloatCst>),
+            var,
+            sense,
+        });
+        self.lpmodel
+            .change_column_cost(self.get_objective_column().unwrap(), 1.);
+
+        let factors = coefs
+            .into_iter()
+            .chain([(self.get_objective_column().unwrap(), -1.)])
+            .collect::<Vec<_>>();
+
+        self.add_row(factors.into_iter(), Some(0.), Some(0.));
+        self.lpmodel.set_sense(sense);
+
+        self.get_objective_column().unwrap()
+    }
+
+    fn get_objective_current_bound(&self) -> Option<IntCst> {
+        self.get_objective_sense().map(|sense| match sense {
+            LpObjectiveSense::Maximise => self.get_column_upper_bound(self.get_objective_column().unwrap()),
+            LpObjectiveSense::Minimise => self.get_column_lower_bound(self.get_objective_column().unwrap()),
+        })
+    }
+    fn get_objective_column(&self) -> Option<LpCol> {
+        self.lpobjective.as_ref().map(|lpoptim| lpoptim.col)
+    }
+    fn get_objective_var(&self) -> Option<Var> {
+        self.lpobjective.as_ref().map(|lpoptim| lpoptim.var)
+    }
+    fn get_objective_sense(&self) -> Option<LpObjectiveSense> {
+        self.lpobjective.as_ref().map(|lpoptim| lpoptim.sense)
+    }
+
+    fn set_lplit(
+        &mut self,
+        lplit: LpLit,
+        cause: LpEventCause,
+        model: &mut Domains,
+        identity: ReasonerId,
+        bindings: &LpRelaxBindings,
+    ) -> Result<(), Contradiction> {
+        debug_assert!(identity == ReasonerId::Extra(0));
+
+        let (lp_event_index, implied_lits) = {
+            let prev_lplit = match lplit.tpe {
+                LpLitType::GEQ => LpLit::geq(lplit.col, self.get_column_lower_bound(lplit.col)),
+                LpLitType::LEQ => LpLit::leq(lplit.col, self.get_column_upper_bound(lplit.col)),
+            };
+            let bounds = match lplit.tpe {
+                LpLitType::GEQ => lplit.val..self.get_column_upper_bound(lplit.col),
+                LpLitType::LEQ => self.get_column_lower_bound(lplit.col)..lplit.val,
+            };
+            if lplit.strictly_entails(prev_lplit) && bounds.start <= bounds.end {
+                self.lpmodel.change_column_bounds(lplit.col, bounds);
+
+                let cause_is_main_model = matches!(cause, LpEventCause::MainModel(_));
+                let lpevent_index = self.trail.push(LpEvent::new(lplit, prev_lplit, cause));
+
+                if !cause_is_main_model {
+                    (Some(lpevent_index), bindings.compute_implied_lits(lplit))
+                } else {
+                    (Some(lpevent_index), None)
+                }
+            } else {
+                (None, None)
+            }
+        };
+
+        if let (Some(lpevent_index), Some(implied_lits)) = (lp_event_index, implied_lits) {
+            for lit in implied_lits {
+                if let Err(invalid) = model.set(lit, identity.cause(ModelUpdateCause(lpevent_index))) {
+                    return Err(Contradiction::InvalidUpdate(invalid));
+                }
+            }
+        }
+        Ok(())
+    }
+    fn set_backtrack_point(&mut self) -> DecLvl {
+        self.trail.save_state()
+    }
+    fn undo_to_last_backtrack_point(&mut self) {
+        self.lpmodel.clear_solver().unwrap();
+
+        self.trail.restore_last_with(|ev| {
+            let bounds = match ev.new_lplit.tpe {
+                LpLitType::GEQ => {
+                    ev.prev_lplit.val..float_as_exact_int_cst(self.lpmodel.get_column_bounds(ev.new_lplit.col).1)
+                }
+                LpLitType::LEQ => {
+                    float_as_exact_int_cst(self.lpmodel.get_column_bounds(ev.new_lplit.col).0)..ev.prev_lplit.val
+                }
+            };
+            self.lpmodel.change_column_bounds(ev.new_lplit.col, bounds);
+        });
+    }
+    fn solve_or_iis(&mut self, stats: &mut LpRelaxStats) -> Result<Result<LpSolution, LpIis>, highs::HighsStatus> {
+        let time = std::time::Instant::now();
+
+        let res = self.lpmodel.solve_or_iis();
+
+        if res.is_err() {
+            self.lpmodel.clear_solver().unwrap();
+        }
+
+        stats.lpruns_time += time.elapsed();
+        stats.lpruns += 1;
+
+        res
+    }
+}
+
+#[derive(Clone)]
+pub struct LpRelax {
+    id: ReasonerId,
+
+    state: LpRelaxState,
+    bindings: LpRelaxBindings,
+
+    //prev_propagation_attempt_trail_info: (DecLvl, u32, bool),
+    stats: LpRelaxStats,
+    config: LpRelaxConfig,
+    // num_propagation_call: usize,
+}
+unsafe impl Send for LpRelax {}
+unsafe impl Sync for LpRelax {}
+
+impl Default for LpRelax {
+    fn default() -> Self {
+        Self {
+            id: ReasonerId::Extra(0),
+            state: LpRelaxState::default(),
+            bindings: LpRelaxBindings::default(),
+            //prev_propagation_attempt_trail_info: (DecLvl::ROOT, 0, false),
+            stats: LpRelaxStats::default(),
+            config: LpRelaxConfig::default(),
+            // num_propagation_call: 0,
+        }
+    }
+}
+impl LpRelax {
+    pub fn with_config(config: LpRelaxConfig) -> Self {
+        Self {
+            config,
+            ..Default::default()
+        }
+    }
+    pub fn num_rows(&self) -> usize {
+        self.state.num_rows()
+    }
+    pub fn num_columns(&self) -> usize {
+        self.state.num_columns()
+    }
+    pub fn get_column_lower_bound(&self, col: LpCol) -> IntCst {
+        self.state.get_column_lower_bound(col)
+    }
+    pub fn get_column_upper_bound(&self, col: LpCol) -> IntCst {
+        self.state.get_column_upper_bound(col)
+    }
+
+    pub fn add_column_01(&mut self) -> LpCol {
+        self.add_column(Some(0.), Some(1.))
+    }
+
+    pub fn add_column(&mut self, lb: Option<FloatCst>, ub: Option<FloatCst>) -> LpCol {
+        self.state.add_column(lb, ub)
+    }
+
+    pub fn add_columns(&mut self, lbs_ubs: &[(Option<FloatCst>, Option<FloatCst>)]) -> Vec<LpCol> {
+        self.state.add_columns(lbs_ubs)
+    }
+
+    pub fn tighten_column(&mut self, col: LpCol, lb: Option<FloatCst>, ub: Option<FloatCst>) -> bool {
+        self.state.tighten_column(col, lb, ub)
+    }
+    pub fn change_column(&mut self, col: LpCol, lb: Option<FloatCst>, ub: Option<FloatCst>) {
+        self.state.change_column(col, lb, ub)
+    }
+
+    pub fn add_row(
+        &mut self,
+        row_coefs: impl Iterator<Item = (LpCol, FloatCst)>,
+        lb: Option<FloatCst>,
+        ub: Option<FloatCst>,
+    ) -> LpRow {
+        self.state.add_row(row_coefs, lb, ub)
+    }
+
+    pub fn add_rows(
+        &mut self,
+        rows_coefs: &[Vec<(LpCol, FloatCst)>],
+        lbs_ubs: &[(Option<FloatCst>, Option<FloatCst>)],
+    ) -> Vec<LpRow> {
+        self.state.add_rows(rows_coefs, lbs_ubs)
+    }
+
+    pub fn add_objective_column(
+        &mut self,
+        var: Var,
+        coefs: impl Iterator<Item = (LpCol, FloatCst)>,
+        sense: LpObjectiveSense,
+    ) -> LpCol {
+        self.state.add_objective_column(var, coefs, sense)
+    }
+
+    pub fn get_objective_column(&self) -> Option<LpCol> {
+        self.state.get_objective_column()
+    }
+    pub fn get_objective_var(&self) -> Option<Var> {
+        self.state.get_objective_var()
+    }
+    pub fn get_objective_sense(&self) -> Option<LpObjectiveSense> {
+        self.state.get_objective_sense()
+    }
+
+    pub fn add_var_half_binding(&mut self, var: Var, func: std::sync::Arc<LitToLpLitsBindingFn>) {
+        assert!(self.state.trail.current_decision_level() == DecLvl::ROOT);
+        self.bindings.add_lit_to_lplits_binding(var, func);
+    }
+    pub fn add_col_half_binding(&mut self, col: LpCol, func: std::sync::Arc<LpLitToLitsBindingFn>) {
+        assert!(self.state.trail.current_decision_level() == DecLvl::ROOT);
+        self.bindings.add_lplit_to_lits_binding(col, func);
+    }
+    pub fn add_var_half_binding_default(&mut self, var: Var, col: LpCol) {
+        assert!(self.state.trail.current_decision_level() == DecLvl::ROOT);
+        self.bindings.add_lit_to_lplits_binding_default(var, col);
+    }
+    pub fn add_col_half_binding_default(&mut self, col: LpCol, var: Var) {
+        assert!(self.state.trail.current_decision_level() == DecLvl::ROOT);
+        self.bindings.add_lplit_to_lits_binding_default(var, col);
+    }
+
+    fn process_model_events(&mut self, model: &mut Domains) -> Result<(), Contradiction> {
+        while let Some(model_event) = self.state.model_events.pop(model.trail()) {
+            let lit = model_event.new_literal();
+
+            // Ignore model events that originate from us (this reasoner),
+            // as they were already pushed to our (local) trail.
+            if let Some(x) = model_event.cause.as_external_inference()
+                && x.writer == self.identity()
+            {
+                continue;
+            }
+            if let Some(lplits) = self.bindings.compute_implied_lplits(lit) {
+                for lplit in lplits {
+                    self.state.set_lplit(
+                        lplit,
+                        LpEventCause::MainModel(lit),
+                        model,
+                        self.identity(),
+                        &self.bindings,
+                    )?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_feasibility(&mut self) -> Result<(), Contradiction> {
+        match self.state.solve_or_iis(&mut self.stats) {
+            Ok(Err(iis)) => Err(self.build_contradiction(iis)),
+            _ => Ok(()),
+        }
+    }
+    fn propagate_reduced_costs_strengthtening(&mut self, model: &mut Domains) -> Result<(), Contradiction> {
+        let obj_col = self
+            .get_objective_column()
+            .expect("Reduced costs strengthtening requires an objective.");
+
+        let Some((optim_obj_val, nz_reduced_costs)) = {
+            match self.state.solve_or_iis(&mut self.stats) {
+                Ok(Ok(sol)) => {
+                    let opt_obj_val = sol.columns()[obj_col.index()];
+                    let nz_reduced_costs = sol
+                        .dual_columns()
+                        .iter()
+                        .enumerate()
+                        .filter(|(col, _)| *col != obj_col.index())
+                        .filter_map(|(col, &rc)| (rc != 0.).then_some((LpCol::from(col), rc, sol.columns()[col])))
+                        .collect::<Vec<_>>();
+
+                    //debug_assert!(nz_reduced_costs.iter().all(|&(col,_, _)| col != obj_col));
+                    Ok(Some((opt_obj_val, nz_reduced_costs)))
+                }
+                Ok(Err(iis)) => Err(self.build_contradiction(iis)),
+                Err(_) => Ok(None), // TODO ? Highs Error ?
+            }
+        }?
+        else {
+            return Ok(());
+        };
+
+        // Skip if the optimal objective computed above is too close to the incumbent (previous best known objective value).
+        let obj_incumbent_bound = self.state.get_objective_current_bound().unwrap();
+        let obj_diff = FloatCst::from(obj_incumbent_bound) - optim_obj_val;
+        if self.config.use_propagation_skips && (obj_diff).abs() < 1. {
+            return Ok(());
+        }
+
+        let reason = {
+            let mut reason = vec![];
+            for &(col, rc, _) in &nz_reduced_costs {
+                if rc > 0. {
+                    reason.push(LpLit::geq(col, self.get_column_lower_bound(col)));
+                } else if rc < 0. {
+                    reason.push(LpLit::leq(col, self.get_column_upper_bound(col)));
+                } else {
+                    unreachable!();
+                }
+            }
+            match self.get_objective_sense() {
+                Some(LpObjectiveSense::Minimise) => reason.push(LpLit::geq(obj_col, obj_incumbent_bound)),
+                Some(LpObjectiveSense::Maximise) => reason.push(LpLit::leq(obj_col, obj_incumbent_bound)),
+                None => unreachable!(),
+            };
+            reason
+        };
+
+        for (col, rc, val) in nz_reduced_costs {
+            let lplit = if rc > 0. {
+                LpLit::geq(col, float_as_ceil_int_cst(val + obj_diff / rc))
+            } else if rc < 0. {
+                LpLit::leq(col, float_as_floor_int_cst(val + obj_diff / rc))
+            } else {
+                unreachable!();
+            };
+            self.state.set_lplit(
+                lplit,
+                LpEventCause::ReducedCostStrengthtening(reason.clone()),
+                model,
+                self.identity(),
+                &self.bindings,
+            )?;
+        }
+        self.state.set_lplit(
+            match self.get_objective_sense() {
+                Some(LpObjectiveSense::Minimise) => LpLit::geq(obj_col, float_as_ceil_int_cst(optim_obj_val)),
+                Some(LpObjectiveSense::Maximise) => LpLit::leq(obj_col, float_as_floor_int_cst(optim_obj_val)),
+                None => unreachable!(),
+            },
+            LpEventCause::ReducedCostStrengthtening(reason.clone()),
+            model,
+            self.identity(),
+            &self.bindings,
+        )?;
+        Ok(())
+    }
+
+    fn build_contradiction(&self, iis: LpIis) -> Contradiction {
+        /*for r in iis.rows() {
+            println!("{r:?}");
+        }*/
+        let mut conjunction_builder = ConjunctionBuilder::new();
+
+        for &(col, status) in iis.columns() {
+            match status {
+                highs::HighsIisBoundStatus::Lower => {
+                    let lplit = LpLit::geq(col, self.state.get_column_lower_bound(col));
+                    if let Some(lits) = self.bindings.compute_implied_lits(lplit) {
+                        for lit in lits {
+                            conjunction_builder.push(lit);
+                        }
+                    }
+                }
+                highs::HighsIisBoundStatus::Upper => {
+                    let lplit = LpLit::leq(col, self.state.get_column_upper_bound(col));
+                    if let Some(lits) = self.bindings.compute_implied_lits(lplit) {
+                        for lit in lits {
+                            conjunction_builder.push(lit);
+                        }
+                    }
+                }
+                highs::HighsIisBoundStatus::Boxed => {
+                    // i.e. equal, i.e. both Lower and Upper
+                    let lplit_lb = LpLit::geq(col, self.state.get_column_lower_bound(col));
+                    if let Some(lits) = self.bindings.compute_implied_lits(lplit_lb) {
+                        for lit in lits {
+                            conjunction_builder.push(lit);
+                        }
+                    }
+                    let lplit_ub = LpLit::leq(col, self.state.get_column_upper_bound(col));
+                    if let Some(lits) = self.bindings.compute_implied_lits(lplit_ub) {
+                        for lit in lits {
+                            conjunction_builder.push(lit);
+                        }
+                    }
+                }
+                highs::HighsIisBoundStatus::Free => (),
+                s => panic!("Unknown highs status {s:?}"),
+            }
+        }
+
+        // Supplement with literals (if any) implied by the current bounds of columns marked as MaybeInConflict:
+        // their participation in the infeasibility is uncertain, but including their bounds
+        // keeps the explanation sound at the cost of potentially adding unnecessary literals.
+        for i in 0..self.num_columns() {
+            let col = LpCol::from(i);
+            if iis.contains_column_maybe(col) {
+                let lplit_lb = LpLit::geq(col, self.state.get_column_lower_bound(col));
+                if let Some(lits) = self.bindings.compute_implied_lits(lplit_lb) {
+                    for lit in lits {
+                        conjunction_builder.push(lit);
+                    }
+                }
+                let lplit_ub = LpLit::leq(col, self.state.get_column_upper_bound(col));
+                if let Some(lits) = self.bindings.compute_implied_lits(lplit_ub) {
+                    for lit in lits {
+                        conjunction_builder.push(lit);
+                    }
+                }
+            }
+        }
+
+        let mut expl = Explanation::new();
+        expl.extend(conjunction_builder.build());
+        Contradiction::Explanation(expl)
+    }
+}
+
+impl Theory for LpRelax {
+    fn identity(&self) -> ReasonerId {
+        self.id
+    }
+
+    fn propagate(&mut self, model: &mut Domains) -> Result<(), Contradiction> {
+        let model_updates_to_process = self.state.model_events.num_pending(model.trail());
+
+        if model_updates_to_process > 0 {
+            self.process_model_events(model)?;
+        }
+
+        // BROKEN // NOTE: This is a *hack* to prevent solving the LP on the "initial" propagation performed before search.
+        // BROKEN //       Indeed, in very simple problems, the LP relaxation (and its solving overhead) might not
+        // BROKEN //       even be needed to detect unsatisfiability on the first propagation loop.
+        // BROKEN self.num_propagation_call += 1;
+        // BROKEN if self.config.use_propagation_skips && self.num_propagation_call <= 2 {
+        // BROKEN     return Ok(());
+        // BROKEN }
+        //
+        // TODO: Need to find a way to avoid solving the LP when unsatisfiability
+        //       can be proven on the first propagation loop without needing it.
+
+        if model_updates_to_process == 0 || !self.config.use_propagation_skips {
+            if self.config.use_propagation_skips
+                && (self.num_columns() == 0 || (self.num_rows() == 0 && self.state.lpobjective.is_none()))
+            {
+                return Ok(());
+            }
+
+            /*if !self.config.no_propagation_skips
+                && self.state.trail.saved_states.len() > 1
+                && self.state.trail.saved_states[self.state.trail.num_saved() as usize - 1] == self.state.trail.trail.len()
+            {
+                return Ok(());
+            }*/
+
+            // TODO: allow propagation after a backtrack.
+            if self.config.use_propagation_skips && self.current_decision_level() > DecLvl::new(0) {
+                return Ok(());
+            }
+
+            if self.state.lpobjective.is_some() {
+                return self.propagate_reduced_costs_strengthtening(model);
+            } else {
+                return self.check_feasibility();
+            }
+        }
+        Ok(())
+    }
+
+    fn explain(
+        &mut self,
+        literal: Lit,
+        context: InferenceCause,
+        model: &DomainsSnapshot,
+        out_explanation: &mut Explanation,
+    ) {
+        let mut add_to_explanation = |l: Lit| {
+            debug_assert!(model.entails(l), "{:?} {:#?}", l, self.state.trail.trail);
+            out_explanation.push(l);
+        };
+        debug_assert_eq!(context.writer, self.identity());
+
+        let ModelUpdateCause(lpevent_index) = ModelUpdateCause::from(context.payload);
+
+        debug_assert!(
+            self.bindings
+                .compute_implied_lits(self.state.trail.get_event(lpevent_index).new_lplit)
+                .map(|lits| lits.into_iter().any(|l| l == literal))
+                .unwrap_or_default()
+        );
+
+        match &self.state.trail.get_event(lpevent_index).cause {
+            LpEventCause::MainModel(model_lit) => add_to_explanation(*model_lit),
+            LpEventCause::ReducedCostStrengthtening(reason) => {
+                for &lplit in reason {
+                    let lits = self.bindings.compute_implied_lits(lplit).unwrap();
+
+                    let mut lits_not_empty = false;
+                    for lit in lits {
+                        lits_not_empty = true;
+                        add_to_explanation(lit);
+                    }
+                    assert!(
+                        lits_not_empty,
+                        "any lp lit found here must have imply a non-empty conjunction of model lits"
+                    );
+                }
+            }
+        }
+    }
+
+    fn print_stats(&self) {
+        println!("# lp runs: {}", self.stats.lpruns);
+        println!("# lp runs time: {:.6} s", self.stats.lpruns_time.as_secs_f64());
+        //println!("# time spent changing column bounds: {} s", self.stats.lp_bounds_change_time.as_secs_f64());
+        //println!("# time spent computing implied lits: {:.6} s", self.stats.implications_time.as_secs_f64());
+    }
+
+    fn clone_box(&self) -> Box<dyn Theory> {
+        Box::new(self.clone())
+    }
+}
+
+impl Backtrack for LpRelax {
+    fn save_state(&mut self) -> DecLvl {
+        self.state.set_backtrack_point()
+    }
+    fn num_saved(&self) -> u32 {
+        self.state.trail.num_saved()
+    }
+    fn restore_last(&mut self) {
+        self.state.undo_to_last_backtrack_point();
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::LpCol;
+    use crate::{LpRelax, LpRelaxConfig};
+    use aries_solver::backtrack::Backtrack;
+    use aries_solver::core::IntCst;
+    use aries_solver::core::state::Cause;
+    use aries_solver::core::state::Explanation;
+    use aries_solver::prelude::Domains;
+    use aries_solver::reasoners::Contradiction;
+    use aries_solver::reasoners::Theory;
+
+    #[test]
+    fn test_trail_backtrack() {
+        let mut model = Domains::new();
+
+        let var2 = model.new_var(0, 10);
+        let var3 = model.new_var(0, 10);
+
+        model.add_implication(var2.leq(5), var3.leq(5));
+
+        let mut theory = LpRelax::with_config(LpRelaxConfig {
+            use_propagation_skips: false,
+        });
+
+        let col2 = theory.add_column(Some(0.), Some(10.));
+        let col3 = theory.add_column(Some(0.), Some(10.));
+
+        theory.add_var_half_binding_default(var2, col2);
+        theory.add_col_half_binding_default(col2, var2);
+
+        theory.add_var_half_binding_default(var3, col3);
+        theory.add_col_half_binding_default(col3, var3);
+
+        let assert_col_bounds = |theory: &mut LpRelax, col: LpCol, col_bounds: (IntCst, IntCst)| {
+            assert_eq!(
+                (theory.get_column_lower_bound(col), theory.get_column_upper_bound(col)),
+                col_bounds
+            )
+        };
+
+        assert_col_bounds(&mut theory, col2, (0, 10));
+        assert_col_bounds(&mut theory, col3, (0, 10));
+
+        model.save_state();
+        theory.save_state();
+        assert_eq!(model.set(var2.leq(8), Cause::Decision), Ok(true));
+        assert!(theory.propagate(&mut model).is_ok());
+
+        assert_col_bounds(&mut theory, col2, (0, 8));
+        assert_col_bounds(&mut theory, col3, (0, 10));
+
+        model.save_state();
+        theory.save_state();
+        assert_eq!(model.set(var3.leq(8), Cause::Decision), Ok(true));
+        assert!(theory.propagate(&mut model).is_ok());
+
+        assert_col_bounds(&mut theory, col2, (0, 8));
+        assert_col_bounds(&mut theory, col3, (0, 8));
+
+        model.restore_last();
+        theory.restore_last();
+
+        assert_col_bounds(&mut theory, col2, (0, 8));
+        assert_col_bounds(&mut theory, col3, (0, 10));
+
+        model.save_state();
+        theory.save_state();
+
+        assert_eq!(model.set(var2.leq(5), Cause::Decision), Ok(true));
+        assert!(theory.propagate(&mut model).is_ok());
+
+        assert_col_bounds(&mut theory, col2, (0, 5));
+        assert_col_bounds(&mut theory, col3, (0, 5));
+
+        model.restore_last();
+        theory.restore_last();
+
+        assert_col_bounds(&mut theory, col2, (0, 8));
+        assert_col_bounds(&mut theory, col3, (0, 10));
+
+        model.restore_last();
+        theory.restore_last();
+
+        assert_col_bounds(&mut theory, col2, (0, 10));
+        assert_col_bounds(&mut theory, col3, (0, 10));
+    }
+
+    #[test]
+    fn test_infeas() {
+        let mut model = Domains::new();
+
+        let avar = model.new_var(0, 1);
+        let bvar = model.new_var(0, 1);
+
+        let mut theory = LpRelax::with_config(LpRelaxConfig {
+            use_propagation_skips: false,
+        });
+
+        let acol = theory.add_column(Some(0.), Some(1.));
+        let bcol = theory.add_column(Some(0.), Some(1.));
+
+        theory.add_var_half_binding_default(avar, acol);
+        theory.add_col_half_binding_default(acol, avar);
+
+        theory.add_var_half_binding_default(bvar, bcol);
+        theory.add_col_half_binding_default(bcol, bvar);
+
+        theory.add_row([(acol, 1.), (bcol, 1.)].into_iter(), Some(1.), None);
+
+        let _ = model.set_ub(avar, 0, Cause::Decision).unwrap();
+        let _ = model.set_ub(bvar, 0, Cause::Decision).unwrap();
+
+        let expl = match theory.propagate(&mut model) {
+            Err(Contradiction::Explanation(expl)) => expl,
+            _ => Explanation::new(),
+        };
+        assert_eq!(expl.literals(), [avar.leq(0), bvar.leq(0)]);
+    }
+}

--- a/solver/lprelax/src/lib.rs
+++ b/solver/lprelax/src/lib.rs
@@ -175,7 +175,8 @@ impl LpRelaxState {
         };
         assert!(lb <= ub);
 
-        self.lpmodel.change_column_bounds(col, lb..ub);
+        self.lpmodel
+            .change_column_bounds(col, int_cst_as_float(lb)..=int_cst_as_float(ub));
         res
     }
     fn change_column(&mut self, col: LpCol, lb: Option<FloatCst>, ub: Option<FloatCst>) {
@@ -192,7 +193,8 @@ impl LpRelaxState {
         };
         assert!(lb <= ub);
 
-        self.lpmodel.change_column_bounds(col, lb..ub);
+        self.lpmodel
+            .change_column_bounds(col, int_cst_as_float(lb)..=int_cst_as_float(ub));
     }
     fn add_row(
         &mut self,
@@ -261,9 +263,10 @@ impl LpRelaxState {
     }
 
     fn get_objective_current_bound(&self) -> Option<IntCst> {
+        let obj_col = self.get_objective_column().unwrap();
         self.get_objective_sense().map(|sense| match sense {
-            LpObjectiveSense::Maximise => self.get_column_upper_bound(self.get_objective_column().unwrap()),
-            LpObjectiveSense::Minimise => self.get_column_lower_bound(self.get_objective_column().unwrap()),
+            LpObjectiveSense::Maximise => self.get_column_upper_bound(obj_col),
+            LpObjectiveSense::Minimise => self.get_column_lower_bound(obj_col),
         })
     }
     fn get_objective_column(&self) -> Option<LpCol> {
@@ -292,10 +295,14 @@ impl LpRelaxState {
                 LpLitType::LEQ => LpLit::leq(lplit.col, self.get_column_upper_bound(lplit.col)),
             };
             let bounds = match lplit.tpe {
-                LpLitType::GEQ => lplit.val..self.get_column_upper_bound(lplit.col),
-                LpLitType::LEQ => self.get_column_lower_bound(lplit.col)..lplit.val,
+                LpLitType::GEQ => {
+                    int_cst_as_float(lplit.val)..=int_cst_as_float(self.get_column_upper_bound(lplit.col))
+                }
+                LpLitType::LEQ => {
+                    int_cst_as_float(self.get_column_lower_bound(lplit.col))..=int_cst_as_float(lplit.val)
+                }
             };
-            if lplit.strictly_entails(prev_lplit) && bounds.start <= bounds.end {
+            if lplit.strictly_entails(prev_lplit) && bounds.start() <= bounds.end() {
                 self.lpmodel.change_column_bounds(lplit.col, bounds);
 
                 let cause_is_main_model = matches!(cause, LpEventCause::MainModel(_));
@@ -329,10 +336,10 @@ impl LpRelaxState {
         self.trail.restore_last_with(|ev| {
             let bounds = match ev.new_lplit.tpe {
                 LpLitType::GEQ => {
-                    ev.prev_lplit.val..float_as_exact_int_cst(self.lpmodel.get_column_bounds(ev.new_lplit.col).1)
+                    int_cst_as_float(ev.prev_lplit.val)..=self.lpmodel.get_column_bounds(ev.new_lplit.col).1
                 }
                 LpLitType::LEQ => {
-                    float_as_exact_int_cst(self.lpmodel.get_column_bounds(ev.new_lplit.col).0)..ev.prev_lplit.val
+                    self.lpmodel.get_column_bounds(ev.new_lplit.col).0..=int_cst_as_float(ev.prev_lplit.val)
                 }
             };
             self.lpmodel.change_column_bounds(ev.new_lplit.col, bounds);
@@ -536,7 +543,7 @@ impl LpRelax {
 
         // Skip if the optimal objective computed above is too close to the incumbent (previous best known objective value).
         let obj_incumbent_bound = self.state.get_objective_current_bound().unwrap();
-        let obj_diff = FloatCst::from(obj_incumbent_bound) - optim_obj_val;
+        let obj_diff = int_cst_as_float(obj_incumbent_bound) - optim_obj_val;
         if self.config.use_propagation_skips && (obj_diff).abs() < 1. {
             return Ok(());
         }

--- a/solver/lprelax/src/lplit.rs
+++ b/solver/lprelax/src/lplit.rs
@@ -1,0 +1,60 @@
+use aries_solver::prelude::{IntCst, Lit, Var};
+
+use crate::LpCol;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum LpLitType {
+    GEQ,
+    LEQ,
+}
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub struct LpLit {
+    pub col: LpCol,
+    pub tpe: LpLitType,
+    pub val: IntCst,
+}
+impl LpLit {
+    pub fn new(col: LpCol, tpe: LpLitType, val: IntCst) -> Self {
+        Self { col, tpe, val }
+    }
+    pub fn from_model_lit(col: LpCol, lit: Lit) -> Self {
+        let (tpe, val) = match lit.relation() {
+            aries_solver::core::Relation::Gt => (LpLitType::GEQ, -lit.ub_value()),
+            aries_solver::core::Relation::Leq => (LpLitType::LEQ, lit.ub_value()),
+        };
+        Self { col, tpe, val }
+    }
+    pub fn leq(col: LpCol, val: IntCst) -> Self {
+        Self {
+            col,
+            tpe: LpLitType::LEQ,
+            val,
+        }
+    }
+    pub fn geq(col: LpCol, val: IntCst) -> Self {
+        Self {
+            col,
+            tpe: LpLitType::GEQ,
+            val,
+        }
+    }
+    pub fn into_model_lit(self, var: Var) -> Lit {
+        match self.tpe {
+            LpLitType::LEQ => var.leq(self.val),
+            LpLitType::GEQ => var.geq(self.val),
+        }
+    }
+    pub fn entails(&self, other: Self) -> bool {
+        if self.tpe == other.tpe {
+            match self.tpe {
+                LpLitType::GEQ => self.val >= other.val,
+                LpLitType::LEQ => self.val <= other.val,
+            }
+        } else {
+            false
+        }
+    }
+    pub fn strictly_entails(&self, other: Self) -> bool {
+        self.entails(other) && self.val != other.val
+    }
+}

--- a/solver/lprelax/src/types.rs
+++ b/solver/lprelax/src/types.rs
@@ -1,0 +1,38 @@
+use aries_solver::prelude::{INT_CST_MAX, INT_CST_MIN, IntCst};
+
+pub type LpCol = highs::Col;
+pub type LpRow = highs::Row;
+pub type LpSolution = highs::Solution;
+pub type LpIis = highs::Iis;
+pub type LpModel = highs::Model;
+pub type LpObjectiveSense = highs::Sense;
+
+pub type FloatCst = f64;
+pub fn float_as_exact_int_cst(value: FloatCst) -> IntCst {
+    if value <= INT_CST_MIN.into() {
+        INT_CST_MIN
+    } else if value >= INT_CST_MAX.into() {
+        INT_CST_MAX
+    } else {
+        assert!(value.fract().abs() < 1e-6);
+        value as IntCst
+    }
+}
+pub fn float_as_floor_int_cst(value: FloatCst) -> IntCst {
+    if value <= INT_CST_MIN.into() {
+        INT_CST_MIN
+    } else if value >= INT_CST_MAX.into() {
+        INT_CST_MAX
+    } else {
+        value.floor() as IntCst
+    }
+}
+pub fn float_as_ceil_int_cst(value: FloatCst) -> IntCst {
+    if value <= INT_CST_MIN.into() {
+        INT_CST_MIN
+    } else if value >= INT_CST_MAX.into() {
+        INT_CST_MAX
+    } else {
+        value.ceil() as IntCst
+    }
+}

--- a/solver/lprelax/src/types.rs
+++ b/solver/lprelax/src/types.rs
@@ -8,31 +8,22 @@ pub type LpModel = highs::Model;
 pub type LpObjectiveSense = highs::Sense;
 
 pub type FloatCst = f64;
+
 pub fn float_as_exact_int_cst(value: FloatCst) -> IntCst {
-    if value <= INT_CST_MIN.into() {
-        INT_CST_MIN
-    } else if value >= INT_CST_MAX.into() {
-        INT_CST_MAX
-    } else {
-        assert!(value.fract().abs() < 1e-6);
-        value as IntCst
-    }
+    debug_assert!(value.fract().abs() < 1e-6);
+    let v = (value.clamp(INT_CST_MIN as FloatCst, INT_CST_MAX as FloatCst) as IntCst).clamp(INT_CST_MIN, INT_CST_MAX);
+    debug_assert!((value - v as FloatCst).abs() < 1e-6);
+    v
 }
 pub fn float_as_floor_int_cst(value: FloatCst) -> IntCst {
-    if value <= INT_CST_MIN.into() {
-        INT_CST_MIN
-    } else if value >= INT_CST_MAX.into() {
-        INT_CST_MAX
-    } else {
-        value.floor() as IntCst
-    }
+    float_as_exact_int_cst(value.floor())
 }
 pub fn float_as_ceil_int_cst(value: FloatCst) -> IntCst {
-    if value <= INT_CST_MIN.into() {
-        INT_CST_MIN
-    } else if value >= INT_CST_MAX.into() {
-        INT_CST_MAX
-    } else {
-        value.ceil() as IntCst
-    }
+    float_as_exact_int_cst(value.ceil())
+}
+
+pub fn int_cst_as_float(value: IntCst) -> FloatCst {
+    let v = value as FloatCst;
+    debug_assert!(float_as_exact_int_cst(v) == value);
+    v
 }


### PR DESCRIPTION
This PR introduces (a first implementation of) a LP relaxation reasoner based on the HiGHS solver as a backend.

The reasoner maintains a LP model, whose columns' bounds can be updated by setting "LP literals" (LpLit), analogously to the main CSP model. The main CSP model and LP model can be bound such that the LP model's columns' upper/lower bounds are updated after observing changes on the main CSP variables' upper/lower bounds. Similarly, these two models can be bound such that, when the LP model is found unsatisfiable, the LpLits composing the infeasible subset are replaced by implicant Lits (literals of the main model) yielding a conflict explanation given to the main CSP.

Note that the code is still rather unpolished. It should be mentioned that non-negligeable overhead is due to the internal HiGHS model's updates (when updating column bounds). Moreover, to avoid overhead, the LP is currently solved only at the root decision level. Ultimately, the code is far from perfect and will have to evolve, notably to align with the API of a future incremental LP reasoner in the works.