### PR TITLE
feat(timelines): Enable full propagation in STN

### DIFF
--- a/planning/timelines/src/explain.rs
+++ b/planning/timelines/src/explain.rs
@@ -43,7 +43,12 @@ impl<T: Ord + Clone> ExplainableSolver<T> {
                 c.enforce(&mut encoding);
             }
         }
-        let solver = Solver::new(encoding.store);
+        let mut solver = Solver::new(encoding.store);
+
+        // enable stronger propagation than default in difference logic solver.
+        // this is useful in planning models where bounds are not sufficient to reason on precedence between tasks
+        solver.reasoners.diff.config.theory_propagation = aries_solver::reasoners::stn::TheoryPropagationLevel::Full;
+
         Self {
             solver,
             enablers: assumptions_map,


### PR DESCRIPTION
By default in the STN (aka diff logic) reasoner, the propagation is based solely on bounds.
This enables by default in the timelines solver the full propagation for difference logic, that is significantly more costly but may substantially improve the propagation strength.

Tagging @nrealus and @SachaPiat has you are using this solver and may want to incorporate this change.