### PR TITLE
feat(solver): add table constraint

### DIFF
--- a/solver/src/lang/constraints/mod.rs
+++ b/solver/src/lang/constraints/mod.rs
@@ -3,9 +3,11 @@ mod alternative;
 mod element;
 mod max;
 mod no_overlap;
+mod table;
 
 pub use all_different::AllDifferent;
 pub use alternative::Alternative;
 pub use element::{Element, EqElement};
 pub use max::EqMax;
 pub use no_overlap::{Interval, NoOverlap};
+pub use table::*;

--- a/solver/src/lang/constraints/table.rs
+++ b/solver/src/lang/constraints/table.rs
@@ -1,0 +1,266 @@
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use crate::core::literals::{ConjunctionBuilder, DisjunctionBuilder};
+use crate::lang::{ModelView, VarCst};
+use crate::prelude::*;
+
+/// A set of tuples, representing the allowed values in a table constraint.
+///
+/// Each row represent an allowed assignment to the variables.
+#[derive(Clone)]
+pub struct Table<E> {
+    /// Number of elements in the tuple, corresponding to the number of variables in a table constraint.
+    num_columns: usize,
+    /// Flat representation of a matrix (each line occurs right after the previous one)
+    inner: Vec<E>,
+}
+
+impl<E> Debug for Table<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "table({})", self.num_columns)
+    }
+}
+
+impl<E: Clone> Table<E> {
+    pub fn new(num_columns: usize) -> Table<E> {
+        Table {
+            num_columns,
+            inner: Vec::new(),
+        }
+    }
+
+    pub fn push_line(&mut self, line: &[E]) {
+        assert_eq!(line.len(), self.num_columns);
+        self.inner.extend_from_slice(line);
+    }
+
+    pub fn lines(&self) -> impl Iterator<Item = &[E]> {
+        self.inner.chunks(self.num_columns)
+    }
+
+    pub fn columns(&self) -> impl Iterator<Item = Vec<&E>> {
+        (0..self.num_columns).map(move |i| self.inner.iter().skip(i).step_by(self.num_columns).collect())
+    }
+}
+
+/// Constraint that enforces a tuple of variables to take their values in a specified number of allowed assignments.
+///
+/// ## Optionals
+///
+/// The constraint is in scope when *all* the variables are.
+/// This means that we do *not* ignore absent variables: if a variable is absent, then
+/// the entire constraint is undefined.
+#[derive(Clone, Debug)]
+pub struct InTable {
+    variables: Vec<VarCst>,
+    value_tuples: Arc<Table<IntCst>>,
+}
+
+impl InTable {
+    pub fn new(variables: Vec<VarCst>, allowed_assignments: Arc<Table<IntCst>>) -> Self {
+        assert_eq!(variables.len(), allowed_assignments.num_columns);
+        InTable {
+            variables,
+            value_tuples: allowed_assignments,
+        }
+    }
+}
+
+impl<Ctx: ModelView> BoolExpr<Ctx> for InTable {
+    fn enforce_if(&self, implicant: Lit, ctx: &mut Ctx) {
+        let mut supported_by_a_line: Vec<Lit> = Vec::with_capacity(256);
+
+        let vars = &self.variables;
+        let table = self.value_tuples.as_ref();
+        let model = ctx;
+
+        let mut lines = Vec::new();
+        for tuple in table.lines() {
+            // for each line i, we create a `sup_i` literal such that, if sup_i
+            // is true, the variables takes the value in this line
+
+            // sup_i => vars[k] == tuple_i[k],   for all variable indices k
+
+            assert_eq!(vars.len(), tuple.len());
+            let mut supported_by_this_line = ConjunctionBuilder::with_capacity(tuple.len() * 2);
+            for (&var, &val) in vars.iter().zip(tuple.iter()) {
+                supported_by_this_line.push(model.half_reify(leq(var, val)));
+                supported_by_this_line.push(model.half_reify(geq(var, val)));
+            }
+            let support = model.half_reify(and(supported_by_this_line));
+            lines.push((support, tuple));
+            supported_by_a_line.push(support);
+        }
+
+        // enforce that at least one line matches the variable values
+        // implicant => Or { sup_i | i in tuples indices }
+        model.enforce_if(implicant, or(supported_by_a_line));
+
+        for (k, var) in vars.iter().copied().enumerate() {
+            // for a given variable var = vars[k]
+
+            // all values allowed for var
+            let allowed_values = lines.iter().map(|(_, values)| values[k]).collect_vec();
+            model.enforce_if(implicant, HasValueIn::new(var, allowed_values));
+
+            // zipped supports and values for vars[k] : [ (sup_i, tuples_i[k]) ]
+            let val_supports = lines
+                .iter()
+                .map(|(support, values)| (*support, values[k]))
+                .collect_vec();
+
+            let values = val_supports
+                .iter()
+                .map(|(_, val)| *val)
+                .sorted_unstable()
+                .dedup()
+                .collect_vec();
+            for &n in &values {
+                // var > n  =>  or_i { sup_i | tuple_i[k] > n }
+                let mut ge_clause = DisjunctionBuilder::new();
+                ge_clause.push(!var.gt_lit(n));
+                // var < n  =>  or { sup_i | tuple_i[k] < n }
+                let mut le_clause = DisjunctionBuilder::new();
+                le_clause.push(!var.lt_lit(n));
+
+                for &(support, val) in &val_supports {
+                    if val > n {
+                        ge_clause.push(support);
+                    }
+                    if val < n {
+                        le_clause.push(support);
+                    }
+                }
+                model.enforce_if(implicant, or(ge_clause));
+                model.enforce_if(implicant, or(le_clause));
+            }
+        }
+    }
+
+    fn conj_scope(&self, ctx: &Ctx) -> Conjunction {
+        Conjunction::from_iter(self.variables.iter().map(|var| ctx.presence(*var)))
+    }
+}
+
+/// Constraint that explicitly defines the allowed values for a variable.
+/// This is primarily useful when the domain of a variable has holes in it.
+pub struct HasValueIn {
+    /// Variable on which the constraint is placed
+    variable: VarCst,
+    /// Values that are allowed for this variable.
+    /// The vector is expected to be sorted (and ideally deduplicated)
+    allowed_values: Vec<IntCst>,
+}
+
+impl HasValueIn {
+    pub fn new(variable: VarCst, mut allowed_values: Vec<IntCst>) -> Self {
+        allowed_values.sort();
+        allowed_values.dedup();
+        Self {
+            variable,
+            allowed_values,
+        }
+    }
+}
+
+impl<Ctx: ModelView> BoolExpr<Ctx> for HasValueIn {
+    fn enforce_if(&self, implicant: Lit, ctx: &mut Ctx) {
+        debug_assert!(self.allowed_values.is_sorted());
+
+        if self.allowed_values.is_empty() {
+            ctx.enforce_if(implicant, Lit::FALSE);
+            return;
+        }
+
+        let min = *self.allowed_values.first().unwrap();
+        let max = *self.allowed_values.last().unwrap();
+        ctx.enforce_if(implicant, self.variable.ge_lit(min));
+        ctx.enforce_if(implicant, self.variable.le_lit(max));
+
+        let mut prev = min;
+        for &val in self.allowed_values.iter().skip(1) {
+            if prev != val - 1 {
+                // there is a hole in the domain
+                // [..., prev] U [val, ..]
+                ctx.enforce_if(implicant, or([self.variable.le_lit(prev), self.variable.ge_lit(val)]));
+            }
+            prev = val
+        }
+    }
+
+    fn conj_scope(&self, ctx: &Ctx) -> Conjunction {
+        ctx.presence(self.variable).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+    use super::*;
+
+    #[test]
+    fn simple_test() {
+        let mut table = Table::new(3);
+        table.push_line(&[2, 3, 6]);
+        table.push_line(&[4, 3, 6]);
+        table.push_line(&[2, 5, 6]);
+        test_table(table);
+    }
+
+    #[test]
+    fn test_random_tables() {
+        for i in 0..10 {
+            test_random_table(i);
+        }
+    }
+
+    fn test_random_table(seed: u64) {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let num_vars = rng.random_range(1..10);
+        let num_lines = rng.random_range(0..50);
+
+        println!("\n== Table test ({num_vars} x {num_lines}) ==\n");
+
+        let mut table = Table::new(num_vars);
+        for _ in 0..num_lines {
+            let line: Vec<IntCst> = (0..num_vars).map(|_| rng.random_range(-10..10)).collect_vec();
+            table.push_line(&line);
+        }
+
+        test_table(table);
+    }
+
+    fn test_table(table: Table<IntCst>) {
+        let table = Arc::new(table);
+        let mut model = Model::new();
+        let vars = (0..table.num_columns)
+            .map(|_| model.new_variable(INT_CST_MIN, INT_CST_MAX))
+            .collect_vec();
+
+        model.enforce(in_table(vars.clone(), table.clone()));
+
+        let mut solver = Solver::new(model);
+        solver.set_brancher(crate::solver::search::random::RandomChoice::new(1));
+
+        let Ok(mut assignments) = solver.enumerate(&vars, SearchLimit::None) else {
+            assert_eq!(table.lines().count(), 0);
+            return;
+        };
+        solver.print_stats();
+
+        assignments.sort();
+        assignments.dedup();
+        for ass in &assignments {
+            println!("{ass:?}");
+        }
+
+        let expected_assignments = table.lines().sorted().dedup().map(Vec::from).collect_vec();
+
+        assert_eq!(assignments, expected_assignments);
+    }
+}

--- a/solver/src/lang/expr.rs
+++ b/solver/src/lang/expr.rs
@@ -2,10 +2,12 @@
 //!
 //! These are all re-exported in [`crate::prelude`].
 
+use std::sync::Arc;
+
 use itertools::Itertools;
 
 use crate::core::views::Dom;
-use crate::lang::constraints::{AllDifferent, Alternative, EqMax, Interval, NoOverlap};
+use crate::lang::constraints::{AllDifferent, Alternative, EqMax, HasValueIn, InTable, Interval, NoOverlap, Table};
 use crate::lang::linear::{LinEq, LinLeq, LinNeq};
 use crate::lang::mul::EqMul;
 use crate::lang::*;
@@ -118,4 +120,20 @@ pub fn bool2int<Ctx: ModelView>(b: Lit, model: &mut Ctx) -> LinTerm {
         implies(b, binary_var.geq(1)).enforce(model);
         LinTerm::from(binary_var)
     }
+}
+
+/// Enforces that the list of variables takes a value in the list of allowed value tuples.
+pub fn in_table<Variable: Into<VarCst>>(
+    variables: impl IntoIterator<Item = Variable>,
+    allowed_assignments: impl Into<Arc<Table<IntCst>>>,
+) -> InTable {
+    InTable::new(
+        variables.into_iter().map(|v| v.into()).collect(),
+        allowed_assignments.into(),
+    )
+}
+
+/// Enforces that the variables takes one of the specified value.
+pub fn has_value_in(variable: impl Into<VarCst>, allowed_values: impl IntoIterator<Item = IntCst>) -> HasValueIn {
+    HasValueIn::new(variable.into(), allowed_values.into_iter().collect())
 }

--- a/solver/src/lang/model_view.rs
+++ b/solver/src/lang/model_view.rs
@@ -34,12 +34,12 @@ pub trait ModelView: Dom {
     /// Given a scope literal, returns an equivalent conjunction of scope literals.
     ///
     /// This method is the inverse of [`Self::conjunctive_scope`] and allows breaking an intersection scope into its intersected components.
-    /// If the scope is not an interesection scope, it will return the intersection with a single element.
+    /// If the scope is not an intersection scope, it will return the intersection with a single element.
     fn decompose_scope(&self, scope: Lit) -> Conjunction;
 
-    /// Returns the list of literals that are known to be always implied `l`.
+    /// Returns the list of literals that are known to be always implied by `l`.
     ///
-    /// The mehtod may not find all possible implication.
+    /// The method may not find all possible implications.
     ///
     /// Currently, it will only detect that for implication explicitly declared with [`Domains::add_implication`] (which is only intended for scope literals).
     fn statically_implied_by(&self, l: Lit) -> impl Iterator<Item = Lit>;
@@ -47,13 +47,73 @@ pub trait ModelView: Dom {
     /// Returns `true` if the literal is tautological in this model (entailed at the root level).
     fn statically_entailed(&self, l: Lit) -> bool;
 
+    /// Adds a user-provided propagator to the CP engine, treated as a black-box by the engine.
     fn enforce_user_propagator(&mut self, propagator: impl UserPropagator + 'static);
+
+    /// Half-reifies a boolean expression into a literal `l` such that `l -> bool_expr`
+    /// and returns `l`.
+    ///
+    /// The returned literal will have the same scope as the boolean expression (and notably will be optional if
+    /// the bool expression is not always defined).
+    ///
+    /// Reference for half-reification: "Half Reification and Flattening" (Feydy et al)
+    fn half_reify(&mut self, bool_expr: impl BoolExpr<Self>) -> Lit
+    where
+        Self: Sized,
+    {
+        bool_expr.implicant(self)
+    }
+
+    /// Enforces the boolean expression to be always true *when in scope*.
+    ///
+    /// This method is provided for convenience for models without optional variables (where constraints are always in scope).
+    /// When having models with optional variables, it should always be preferred to use [`Self::enforce_scoped`] that allows
+    /// specifying the scope of a constraint explicitly.
+    fn enforce(&mut self, bool_expr: impl BoolExpr<Self>)
+    where
+        Self: Sized,
+    {
+        bool_expr.enforce(self);
+    }
+
+    /// Enforces the boolean expression to be always, when we are in the provided scope.
+    ///
+    /// The scope may be *smaller* than the one of the boolean expression: it must only hold that
+    /// when `scope` is entailed, the boolean expression is defined.
+    fn enforce_scoped(&mut self, bool_expr: impl BoolExpr<Self>, scope: impl Into<Conjunction>)
+    where
+        Self: Sized,
+    {
+        let scope = scope.into();
+        let scope = self.conjunctive_scope(&scope);
+        // retrieve or create an optional variable that is always true in the scope
+        let tauto = self.tautology_of_scope(scope);
+
+        bool_expr.enforce_if(tauto, self);
+    }
+
+    /// Enforces that if `condition` is *present* and *entailed*, then the boolean expression must be satisfied (and thus defined).
+    ///
+    /// IMPORTANT: it MUST be the case that, whenever `condition` is present, then the boolean expression must be defined.
+    /// See [`Self::opt_enforce_if`] for a variant that relaxes this requirements (with different semantics.)
+    fn enforce_if(&mut self, condition: Lit, bool_expr: impl BoolExpr<Self>)
+    where
+        Self: Sized,
+    {
+        bool_expr.enforce_if(condition, self);
+    }
+
+    /// Enforces that when `condition` is present and entailed, the boolean expression is satisfied or undefined (out of scope).
+    fn opt_enforce_if(&mut self, condition: Lit, bool_expr: impl BoolExpr<Self>)
+    where
+        Self: Sized,
+    {
+        bool_expr.opt_enforce_if(condition, self);
+    }
 
     /// Adds a debug assertion on solutions, i.e., an expression that is assumed to always evaluate to true.
     ///
     /// IMPORTANT: the assertion has NO effect on the solving process and only checked on solutions when debug assertions are enabled (not in release mode)
-    ///
-    /// TODO: this could be provided on the `Model` it self to be more generally useful
     #[track_caller]
     fn add_assertion<Expr: Evaluable<Value = bool> + Debug + Send + Sync + 'static>(&mut self, condition: Expr) {
         // The assertion is costly to create and evaluate so it is only active when debug assertions are activated


### PR DESCRIPTION
This PR adds a a table constraint that is usable in models and decomposes it into clauses.


- chore(solver): Add new convenience methods for posting variables on `ModelView`
- feat(solver): add table constraint.
