### PR TITLE
add Debug to HasValueIn and AllDifferent

### DIFF
--- a/solver/src/lang/constraints/all_different.rs
+++ b/solver/src/lang/constraints/all_different.rs
@@ -12,6 +12,7 @@ use crate::{
 /// Scope: always defined (absent variables are ignored).
 ///
 /// The constraint is decomposed into pair-wise difference constraints between all pairs of terms.
+#[derive(Debug)]
 pub struct AllDifferent {
     vars: Vec<LinSum>,
 }

--- a/solver/src/lang/constraints/all_different.rs
+++ b/solver/src/lang/constraints/all_different.rs
@@ -12,7 +12,7 @@ use crate::{
 /// Scope: always defined (absent variables are ignored).
 ///
 /// The constraint is decomposed into pair-wise difference constraints between all pairs of terms.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AllDifferent {
     vars: Vec<LinSum>,
 }

--- a/solver/src/lang/constraints/table.rs
+++ b/solver/src/lang/constraints/table.rs
@@ -147,7 +147,7 @@ impl<Ctx: ModelView> BoolExpr<Ctx> for InTable {
 
 /// Constraint that explicitly defines the allowed values for a variable.
 /// This is primarily useful when the domain of a variable has holes in it.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HasValueIn {
     /// Variable on which the constraint is placed
     variable: VarCst,

--- a/solver/src/lang/constraints/table.rs
+++ b/solver/src/lang/constraints/table.rs
@@ -147,6 +147,7 @@ impl<Ctx: ModelView> BoolExpr<Ctx> for InTable {
 
 /// Constraint that explicitly defines the allowed values for a variable.
 /// This is primarily useful when the domain of a variable has holes in it.
+#[derive(Debug)]
 pub struct HasValueIn {
     /// Variable on which the constraint is placed
     variable: VarCst,


### PR DESCRIPTION
The constraint HasValueIn now implements the Debug trait.
This is useful for, for example, adding a HasValueIn constraint to a Sched model.