### PR TITLE
ci(ape): add memory limit error to ape script

### DIFF
--- a/planning/scripts/aries_utils/aries_utils/ape.py
+++ b/planning/scripts/aries_utils/aries_utils/ape.py
@@ -24,6 +24,30 @@ class VirtualMemoryLimitExceeded(subprocess.CalledProcessError):
         super().__init__(returncode, cmd, output, stderr)
         self.memory_limit_mb = memory_limit_mb
 
+def _vms_bytes_recursive(proc) -> int:
+    total = proc.memory_info().vms
+    for child in proc.children(recursive=True):
+        try:
+            total += child.memory_info().vms
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return total
+
+def _kill_proc_tree(proc) -> None:
+    try:
+        children = proc.children(recursive=True)
+    except psutil.NoSuchProcess:
+        children = []
+    for child in children:
+        try:
+            child.kill()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    try:
+        proc.kill()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+
 
 @dataclass
 class ApeResult:
@@ -223,7 +247,7 @@ class ApeRunner:
 
     @staticmethod
     def _monitor_memory(
-        proc_pid: int, limit_mb: int, exceeded: threading.Event, poll_interval: float = 0.1
+        proc_pid: int, limit_mb: int, exceeded: threading.Event, poll_interval: float = 0.01
     ) -> None:
         limit_bytes = limit_mb * 1024 * 1024
         try:
@@ -232,11 +256,11 @@ class ApeRunner:
             return
         while True:
             try:
-                vms = proc.memory_info().vms
+                vms = _vms_bytes_recursive(proc)
                 if vms > limit_bytes:
                     print(f"\nMemory limit exceeded ({limit_mb} MB, VMS={vms // 1024 // 1024} MB)")
                     exceeded.set()
-                    proc.kill()
+                    _kill_proc_tree(proc)
                     return
                 time.sleep(poll_interval)
             except (psutil.NoSuchProcess, psutil.AccessDenied):

--- a/planning/scripts/aries_utils/aries_utils/ape.py
+++ b/planning/scripts/aries_utils/aries_utils/ape.py
@@ -145,6 +145,7 @@ class ApeRunner:
         memory_limit_mb: Optional[int] = None,
         check: bool = True,
         capture_output: bool = True,
+        env: Optional[dict[str, str]] = None,
     ) -> ApeResult:
         """
         Run an APE command with the given arguments.
@@ -155,6 +156,9 @@ class ApeRunner:
             memory_limit_mb: Optional memory limit in MB (resident, monitored via psutil)
             check: If True, raise exception on non-zero exit code
             capture_output: If True, capture stdout/stderr (default: True)
+            env: If not None, specifies the environment variables with which to run APE.
+                 If None, inherits the current process' environment.
+                 To use the specified environment on top of the inherited one, `env` will need to be built on top of the `os.environ.copy()` dict.
 
         Returns:
             ApeResult with command output and status
@@ -174,7 +178,7 @@ class ApeRunner:
 
         try:
             if memory_limit_mb is not None:
-                completed = self._run_with_memory_limit(cmd, timeout, memory_limit_mb)
+                completed = self._run_with_memory_limit(cmd, timeout, memory_limit_mb, env=env)
             else:
                 completed = subprocess.run(
                     cmd,
@@ -182,6 +186,7 @@ class ApeRunner:
                     text=True,
                     timeout=timeout,
                     check=False,
+                    env=env,
                 )
 
             ape_result = ApeResult(
@@ -204,7 +209,11 @@ class ApeRunner:
             raise e
 
     def _run_with_memory_limit(
-        self, cmd: list[str], timeout: Optional[int], memory_limit_mb: int
+        self,
+        cmd: list[str],
+        timeout: Optional[int],
+        memory_limit_mb: int,
+        env: Optional[dict[str, str]] = None,
     ) -> subprocess.CompletedProcess:
         exceeded = threading.Event()
 
@@ -213,6 +222,7 @@ class ApeRunner:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            env=env
         )
 
         monitor = threading.Thread(

--- a/planning/scripts/aries_utils/aries_utils/ape.py
+++ b/planning/scripts/aries_utils/aries_utils/ape.py
@@ -1,10 +1,28 @@
 """APE command runner with error reporting."""
 
+import psutil
 import subprocess
 import tempfile
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+
+
+class VirtualMemoryLimitExceeded(subprocess.CalledProcessError):
+    """Raised when a subprocess exceeds its (virtual) memory limit."""
+
+    def __init__(
+        self,
+        returncode: int,
+        cmd: list[str],
+        output: Optional[str] = None,
+        stderr: Optional[str] = None,
+        memory_limit_mb: Optional[int] = None,
+    ):
+        super().__init__(returncode, cmd, output, stderr)
+        self.memory_limit_mb = memory_limit_mb
 
 
 @dataclass
@@ -100,6 +118,7 @@ class ApeRunner:
         self,
         *args: str,
         timeout: Optional[int] = None,
+        memory_limit_mb: Optional[int] = None,
         check: bool = True,
         capture_output: bool = True,
     ) -> ApeResult:
@@ -109,6 +128,7 @@ class ApeRunner:
         Args:
             *args: Arguments to pass to APE (e.g., "validate", "plan.txt")
             timeout: Optional timeout in seconds
+            memory_limit_mb: Optional memory limit in MB (virtual, monitored via psutil)
             check: If True, raise exception on non-zero exit code
             capture_output: If True, capture stdout/stderr (default: True)
 
@@ -118,6 +138,7 @@ class ApeRunner:
         Raises:
             subprocess.CalledProcessError: If check=True and command fails
             subprocess.TimeoutExpired: If command times out
+            VirtualMemoryLimitExceeded: If command exceeds the memory limit
 
         Example:
             >>> ape = ApeRunner()
@@ -128,39 +149,124 @@ class ApeRunner:
         cmd = [self.ape_path] + list(args)
 
         try:
-            result = subprocess.run(
-                cmd,
-                capture_output=capture_output,
-                text=True,
-                timeout=timeout,
-                check=False,  # We'll handle errors ourselves
-            )
+            if memory_limit_mb is not None:
+                completed = self._run_with_memory_limit(cmd, timeout, memory_limit_mb)
+            else:
+                completed = subprocess.run(
+                    cmd,
+                    capture_output=capture_output,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
 
             ape_result = ApeResult(
-                returncode=result.returncode,
-                stdout=result.stdout if capture_output else "",
-                stderr=result.stderr if capture_output else "",
+                returncode=completed.returncode,
+                stdout=completed.stdout if capture_output else "",
+                stderr=completed.stderr if capture_output else "",
                 command=cmd,
             )
 
-            if check and result.returncode != 0:
+            if check and completed.returncode != 0:
                 self._report_error(ape_result)
                 raise subprocess.CalledProcessError(
-                    result.returncode, cmd, result.stdout, result.stderr
+                    completed.returncode, cmd, completed.stdout, completed.stderr
                 )
 
             return ape_result
 
-        except subprocess.TimeoutExpired as _:
-            print(f"\n{'=' * 60}")
-            print(f"APE COMMAND TIMEOUT after {timeout}s")
-            print(f"{'=' * 60}")
-            print(f"\nCommand: {' '.join(cmd)}")
-            print("\nTo reproduce:")
-            print(f"  timeout {timeout}s {' '.join(cmd)}")
-            raise
+        except subprocess.TimeoutExpired as e:
+            self._report_timeout(cmd, timeout)
+            raise e
 
-    def _report_error(self, result: ApeResult):
+    def _run_with_memory_limit(
+        self, cmd: list[str], timeout: Optional[int], memory_limit_mb: int
+    ) -> subprocess.CompletedProcess:
+        exceeded = threading.Event()
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        monitor = threading.Thread(
+            target=self._monitor_memory,
+            args=(proc.pid, memory_limit_mb, exceeded),
+            daemon=True,
+        )
+        monitor.start()
+
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+            raise
+        finally:
+            monitor.join(timeout=2)
+
+        completed = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+
+        if exceeded.is_set():
+            self._report_memory_limit(completed, memory_limit_mb)
+            raise VirtualMemoryLimitExceeded(
+                completed.returncode,
+                cmd,
+                completed.stdout,
+                completed.stderr,
+                memory_limit_mb,
+            )
+
+        return completed
+
+    @staticmethod
+    def _monitor_memory(
+        proc_pid: int, limit_mb: int, exceeded: threading.Event, poll_interval: float = 0.1
+    ) -> None:
+        limit_bytes = limit_mb * 1024 * 1024
+        try:
+            proc = psutil.Process(proc_pid)
+        except psutil.NoSuchProcess:
+            return
+        while True:
+            try:
+                vms = proc.memory_info().vms
+                if vms > limit_bytes:
+                    print(f"\nMemory limit exceeded ({limit_mb} MB, VMS={vms // 1024 // 1024} MB)")
+                    exceeded.set()
+                    proc.kill()
+                    return
+                time.sleep(poll_interval)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                return
+
+    @staticmethod
+    def _report_memory_limit(result: subprocess.CompletedProcess, limit_mb: int) -> None:
+        print(f"\n{'=' * 60}")
+        print(f"APE COMMAND MEMORY LIMIT EXCEEDED ({limit_mb} MB)")
+        print(f"{'=' * 60}")
+        print(f"\nCommand: {' '.join(result.args)}")
+        #print("\nStdout:")
+        #print(result.stdout if result.stdout else "(empty)")
+        #print("\nStderr:")
+        #print(result.stderr if result.stderr else "(empty)")
+        print(f"\nSignal: {-result.returncode}")
+        print("\nTo reproduce:")
+        print(f"  ulimit -v {limit_mb * 1024}; {' '.join(result.args)}")
+
+    @staticmethod
+    def _report_timeout(cmd: list[str], timeout: Optional[int]) -> None:
+        print(f"\n{'=' * 60}")
+        print(f"APE COMMAND TIMEOUT after {timeout}s")
+        print(f"{'=' * 60}")
+        print(f"\nCommand: {' '.join(cmd)}")
+        print("\nTo reproduce:")
+        print(f"  timeout {timeout}s {' '.join(cmd)}")
+
+    @staticmethod
+    def _report_error(result: ApeResult):
         """Report detailed error information."""
         print(f"\n{'=' * 60}")
         print("APE COMMAND FAILED")
@@ -223,7 +329,7 @@ class ApeRunner:
                 timeout=timeout,
             )
             return True
-        except subprocess.CalledProcessError, subprocess.TimeoutExpired:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
             return False
 
     def optimize_plan(
@@ -289,7 +395,7 @@ class ApeRunner:
 
                 return True
 
-            except subprocess.CalledProcessError, subprocess.TimeoutExpired:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
                 return False
             finally:
                 # Clean up temporary file
@@ -300,5 +406,5 @@ class ApeRunner:
             try:
                 self.run(*args, timeout=timeout)
                 return True
-            except subprocess.CalledProcessError, subprocess.TimeoutExpired:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
                 return False

--- a/planning/scripts/aries_utils/aries_utils/ape.py
+++ b/planning/scripts/aries_utils/aries_utils/ape.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from typing import Optional
 
 
-class VirtualMemoryLimitExceeded(subprocess.CalledProcessError):
-    """Raised when a subprocess exceeds its (virtual) memory limit."""
+class RSSMemoryLimitExceeded(subprocess.CalledProcessError):
+    """Raised when a subprocess exceeds its (resident) memory limit."""
 
     def __init__(
         self,
@@ -24,11 +24,11 @@ class VirtualMemoryLimitExceeded(subprocess.CalledProcessError):
         super().__init__(returncode, cmd, output, stderr)
         self.memory_limit_mb = memory_limit_mb
 
-def _vms_bytes_recursive(proc) -> int:
-    total = proc.memory_info().vms
+def _rss_bytes_recursive(proc) -> int:
+    total = proc.memory_info().rss
     for child in proc.children(recursive=True):
         try:
-            total += child.memory_info().vms
+            total += child.memory_info().rss
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
     return total
@@ -152,7 +152,7 @@ class ApeRunner:
         Args:
             *args: Arguments to pass to APE (e.g., "validate", "plan.txt")
             timeout: Optional timeout in seconds
-            memory_limit_mb: Optional memory limit in MB (virtual, monitored via psutil)
+            memory_limit_mb: Optional memory limit in MB (resident, monitored via psutil)
             check: If True, raise exception on non-zero exit code
             capture_output: If True, capture stdout/stderr (default: True)
 
@@ -162,7 +162,7 @@ class ApeRunner:
         Raises:
             subprocess.CalledProcessError: If check=True and command fails
             subprocess.TimeoutExpired: If command times out
-            VirtualMemoryLimitExceeded: If command exceeds the memory limit
+            RSSMemoryLimitExceeded: If command exceeds the memory limit
 
         Example:
             >>> ape = ApeRunner()
@@ -235,7 +235,7 @@ class ApeRunner:
 
         if exceeded.is_set():
             self._report_memory_limit(completed, memory_limit_mb)
-            raise VirtualMemoryLimitExceeded(
+            raise RSSMemoryLimitExceeded(
                 completed.returncode,
                 cmd,
                 completed.stdout,
@@ -256,9 +256,9 @@ class ApeRunner:
             return
         while True:
             try:
-                vms = _vms_bytes_recursive(proc)
-                if vms > limit_bytes:
-                    print(f"\nMemory limit exceeded ({limit_mb} MB, VMS={vms // 1024 // 1024} MB)")
+                rss = _rss_bytes_recursive(proc)
+                if rss > limit_bytes:
+                    print(f"\nMemory limit exceeded ({limit_mb} MB, RSS={rss // 1024 // 1024} MB)")
                     exceeded.set()
                     _kill_proc_tree(proc)
                     return
@@ -278,7 +278,7 @@ class ApeRunner:
         #print(result.stderr if result.stderr else "(empty)")
         print(f"\nSignal: {-result.returncode}")
         print("\nTo reproduce:")
-        print(f"  ulimit -v {limit_mb * 1024}; {' '.join(result.args)}")
+        print(f"  systemd-run --user --scope -p MemoryMax=$(({limit_mb} * 1024 * 1024)) -- {' '.join(result.args)}")
 
     @staticmethod
     def _report_timeout(cmd: list[str], timeout: Optional[int]) -> None:
@@ -353,7 +353,7 @@ class ApeRunner:
                 timeout=timeout,
             )
             return True
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RSSMemoryLimitExceeded):
             return False
 
     def optimize_plan(
@@ -419,7 +419,7 @@ class ApeRunner:
 
                 return True
 
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RSSMemoryLimitExceeded):
                 return False
             finally:
                 # Clean up temporary file
@@ -430,5 +430,5 @@ class ApeRunner:
             try:
                 self.run(*args, timeout=timeout)
                 return True
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, VirtualMemoryLimitExceeded):
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RSSMemoryLimitExceeded):
                 return False

--- a/planning/scripts/aries_utils/aries_utils/ape.py
+++ b/planning/scripts/aries_utils/aries_utils/ape.py
@@ -178,9 +178,9 @@ class ApeRunner:
 
         try:
             if memory_limit_mb is not None:
-                completed = self._run_with_memory_limit(cmd, timeout, memory_limit_mb, env=env)
+                result = self._run_with_memory_limit(cmd, timeout, memory_limit_mb, env=env)
             else:
-                completed = subprocess.run(
+                result = subprocess.run(
                     cmd,
                     capture_output=capture_output,
                     text=True,
@@ -190,16 +190,16 @@ class ApeRunner:
                 )
 
             ape_result = ApeResult(
-                returncode=completed.returncode,
-                stdout=completed.stdout if capture_output else "",
-                stderr=completed.stderr if capture_output else "",
+                returncode=result.returncode,
+                stdout=result.stdout if capture_output else "",
+                stderr=result.stderr if capture_output else "",
                 command=cmd,
             )
 
-            if check and completed.returncode != 0:
+            if check and result.returncode != 0:
                 self._report_error(ape_result)
                 raise subprocess.CalledProcessError(
-                    completed.returncode, cmd, completed.stdout, completed.stderr
+                    result.returncode, cmd, result.stdout, result.stderr
                 )
 
             return ape_result
@@ -241,19 +241,19 @@ class ApeRunner:
         finally:
             monitor.join(timeout=2)
 
-        completed = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+        result = subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
         if exceeded.is_set():
-            self._report_memory_limit(completed, memory_limit_mb)
+            self._report_memory_limit(result, memory_limit_mb)
             raise RSSMemoryLimitExceeded(
-                completed.returncode,
+                result.returncode,
                 cmd,
-                completed.stdout,
-                completed.stderr,
+                result.stdout,
+                result.stderr,
                 memory_limit_mb,
             )
 
-        return completed
+        return result
 
     @staticmethod
     def _monitor_memory(
@@ -282,10 +282,10 @@ class ApeRunner:
         print(f"APE COMMAND MEMORY LIMIT EXCEEDED ({limit_mb} MB)")
         print(f"{'=' * 60}")
         print(f"\nCommand: {' '.join(result.args)}")
-        #print("\nStdout:")
-        #print(result.stdout if result.stdout else "(empty)")
-        #print("\nStderr:")
-        #print(result.stderr if result.stderr else "(empty)")
+        print("\nStdout:")
+        print(result.stdout if result.stdout else "(empty)")
+        print("\nStderr:")
+        print(result.stderr if result.stderr else "(empty)")
         print(f"\nSignal: {-result.returncode}")
         print("\nTo reproduce:")
         print(f"  systemd-run --user --scope -p MemoryMax=$(({limit_mb} * 1024 * 1024)) -- {' '.join(result.args)}")

--- a/planning/scripts/aries_utils/pyproject.toml
+++ b/planning/scripts/aries_utils/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aries-utils"
 version = "0.1.0"
 requires-python = ">=3.14"
-dependencies = []
+dependencies = ["psutil"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
This PR adds a memory limit option to in the utilitary python script that allows to run `ape`.
The script now monitors the `ape` subprocess' RSS memory (resident set size memory) via `psutil` and kills it when the limit is exceeded, raising a new `RSSMemoryLimitExceeded` exception.